### PR TITLE
Cloud build timeout changed to 2hrs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@
 # for more details on image pushing process in Kubernetes.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-timeout: 3600s
+timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Increased the cloud build timeout to 2hrs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #144 

**Special notes for your reviewer**:


**Release note**:
```
none
```