### PR TITLE
Github action added for building the centos base image for ibm-powervs-block-csi-driver

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,58 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+#
+# This test is meant to verify that our Dockerfile can build successfully when
+# changed on the CPU architectures we have made it support being built on.
+#
+name: Build ibm-powervs-block-csi-driver-centos-base
+
+on:
+  push:
+    paths:
+      - "build/base/Dockerfile"
+      - ".github/workflows/docker-build.yml"
+
+jobs:
+  docker:
+    name: Build ibm-powervs-block-csi-driver-centos-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      # Action reference: https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@v1
+
+      # Action reference: https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Action reference: https://github.com/docker/login-action
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Convert repository owner name into lowercase letters
+      # Action reference: https://github.com/ASzc/change-string-case-action
+      - id: repository_owner
+        name: lower case repository owner name
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ github.repository_owner }}
+
+      # Action reference: https://github.com/docker/build-push-action
+      - name: Build container
+        uses: docker/build-push-action@v2
+        with:
+          context: ./build/base
+          platforms: linux/amd64,linux/ppc64le
+          target: centos-base
+          push: true
+          tags: ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/ibm-powervs-block-csi-driver-centos-base:v8.0.0

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# centos base image
+FROM quay.io/centos/centos:stream8 AS centos-base
+RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Added a GitHub Action on Push event to build and push multi arch images to the GitHub packages.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #145 

**Special notes for your reviewer**:


**Release note**:
```
none
```