### PR TITLE
Improve run time for the multi arch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test:
 
 .PHONY: image
 image:
-	docker build -t $(REGISTRY)/$(IMG):$(TAG) . --target debian-base
+	docker build -t $(REGISTRY)/$(IMG):$(TAG) . --target centos-base
 
 .PHONY: push
 push:
@@ -55,16 +55,16 @@ build-image-and-push-linux-amd64: init-buildx
 	{                                                                   \
 	set -e ;                                                            \
 	docker buildx build \
-		--platform linux/amd64 \
-		-t $(REGISTRY)/$(IMG):$(TAG)_linux_amd64 --push . --target debian-base; \
+		--build-arg TARGETPLATFORM=linux/amd64 \
+		-t $(REGISTRY)/$(IMG):$(TAG)_linux_amd64 --push . --target centos-base; \
 	}
 
 build-image-and-push-linux-ppc64le: init-buildx
 	{                                                                   \
 	set -e ;                                                            \
 	docker buildx build \
-		--platform linux/ppc64le \
-		-t $(REGISTRY)/$(IMG):$(TAG)_linux_ppc64le --push . --target debian-base; \
+		--build-arg TARGETPLATFORM=linux/ppc64le \
+		-t $(REGISTRY)/$(IMG):$(TAG)_linux_ppc64le --push . --target centos-base; \
 	}
 
 build-and-push-multi-arch: build-image-and-push-linux-amd64 build-image-and-push-linux-ppc64le


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Improved run time for multi arch build by avoid passing platforms to buildx and passing platform to the base image.
Also changed default target as centos-base.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #146 

**Special notes for your reviewer**:


**Release note**:
```
none
```