### PR TITLE
Pre provisioned volume test cases added

### DIFF
--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -36,9 +36,8 @@ var _ = Describe("[powervs-csi-e2e]Dynamic Provisioning", func() {
 	f := framework.NewDefaultFramework("powervs")
 
 	var (
-		cs clientset.Interface
-		ns *v1.Namespace
-		//powervsDriver driver.PreProvisionedVolumeTestDriver
+		cs           clientset.Interface
+		ns           *v1.Namespace
 		pvTestDriver driver.DynamicPVTestDriver
 		volumeTypes  = powervscloud.ValidVolumeTypes
 		fsTypes      = []string{powervscsidriver.FSTypeXfs}

--- a/tests/e2e/testsuites/pre_provisioned_read_only_volume_tester.go
+++ b/tests/e2e/testsuites/pre_provisioned_read_only_volume_tester.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// PreProvisionedReadOnlyVolumeTest will provision required PV(s), PVC(s) and Pod(s)
+// Testing that the Pod(s) cannot write to the volume when mounted
+type PreProvisionedReadOnlyVolumeTest struct {
+	CSIDriver driver.PreProvisionedVolumeTestDriver
+	Pods      []PodDetails
+}
+
+func (t *PreProvisionedReadOnlyVolumeTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	for _, pod := range t.Pods {
+		tpod, cleanup := pod.SetupWithPreProvisionedVolumes(client, namespace, t.CSIDriver)
+		// defer must be called here for resources not get removed before using them
+		for i := range cleanup {
+			defer cleanup[i]()
+		}
+
+		By("deploying the pod")
+		tpod.Create()
+		defer tpod.Cleanup()
+		By("checking that the pods command exits with an error")
+		tpod.WaitForFailure()
+		By("checking that pod logs contain expected message")
+		body, err := tpod.Logs()
+		framework.ExpectNoError(err, fmt.Sprintf("Error getting logs for pod %s: %v", tpod.pod.Name, err))
+		Expect(string(body)).To(ContainSubstring(expectedReadOnlyLog))
+	}
+}

--- a/tests/e2e/testsuites/pre_provisioned_reclaim_policy_tester.go
+++ b/tests/e2e/testsuites/pre_provisioned_reclaim_policy_tester.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e/driver"
+
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// PreProvisionedReclaimPolicyTest will provision required PV(s) and PVC(s)
+// Testing the correct behavior for different reclaimPolicies
+type PreProvisionedReclaimPolicyTest struct {
+	CSIDriver driver.PreProvisionedVolumeTestDriver
+	Volumes   []VolumeDetails
+}
+
+func (t *PreProvisionedReclaimPolicyTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	for _, volume := range t.Volumes {
+		tpvc, _ := volume.SetupPreProvisionedPersistentVolumeClaim(client, namespace, t.CSIDriver)
+
+		// will delete the PVC
+		// will also wait for PV to be deleted when reclaimPolicy=Delete
+		tpvc.Cleanup()
+		// first check PV stills exists, then manually delete it
+		if tpvc.ReclaimPolicy() == v1.PersistentVolumeReclaimRetain {
+			tpvc.WaitForPersistentVolumePhase(v1.VolumeReleased)
+			tpvc.DeleteBoundPersistentVolume()
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Added  below e2e test case scenarios to test pre provisioned volumes:
- use a pre-provisioned volume and mount it as readOnly in a pod
- use a pre-provisioned volume and retain PV with reclaimPolicy retain
- use a pre-provisioned volume and delete PV with reclaimPolicy delete

Added necessary library methods to test the above scenarios.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```