### PR TITLE
Added default value for expected volume type for volume verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There are several optional parameters that could be passed into ``` CreateVolume
 
 | **Parameters** | **Values** | **Default** | **Description**|
 | ----------------------------- | ----------------------------- | ----------- | ----------------------------- |
+| "type" | tier1, tier3 | tier1 | PowerVS Disk type that will be created during volume creation |
 | "csi.storage.k8s.io/fstype" | xfs, ext2, ext3, ext4 | ext4 | File system type that will be formatted during volume creation. This parameter is case sensitive! |
 
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -122,7 +122,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, errString)
 	}
 
-	var volumeType string
+	volumeType := cloud.DefaultVolumeType
 
 	for key, value := range req.GetParameters() {
 		switch strings.ToLower(key) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

- Added default value for expected volume type on volume details verification during volume creation
- Updated readme with storage class parameter `type`
- Modified unit tests by adding volume type paramter to the request, added test case to verify the volume creation when no volume type parameter is given

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #197 

**Special notes for your reviewer**:


**Release note**:
```
none
```