### PR TITLE
Update storage pool affinity when VM is in Warning state

### DIFF
--- a/adhoc-controllers/controllers/nodeupdate_controller.go
+++ b/adhoc-controllers/controllers/nodeupdate_controller.go
@@ -87,15 +87,14 @@ func (r *NodeUpdateReconciler) Reconcile(_ context.Context, req ctrl.Request) (c
 			if *instance.StoragePoolAffinity {
 				switch *instance.Status {
 				case cloud.PowerVSInstanceStateSHUTOFF, cloud.PowerVSInstanceStateACTIVE:
-					switch instance.Health.Status {
-					case cloud.PowerVSInstanceHealthOK:
+					if *instance.StoragePoolAffinity == cloud.StoragePoolAffinity {
+						klog.Infof("PowerVS instance - %v Storage pool affinity already %t", instance.PvmInstanceID, cloud.StoragePoolAffinity)
+					} else {
 						err := r.getOrUpdate(nodeUpdateScope)
 						if err != nil {
 							klog.Infof("unable to update instance StoragePoolAffinity %v", err)
 							return ctrl.Result{}, errors.Wrapf(err, "failed to reconcile VSI for IBMPowerVSMachine %s/%s", node.Namespace, node.Name)
 						}
-					default:
-						klog.Infof("PowerVS instance - %v health not OK yet", instance.PvmInstanceID)
 					}
 				default:
 					klog.Infof("PowerVS instance - %v state not ACTIVE/SHUTOFF yet", instance.PvmInstanceID)

--- a/pkg/cloud/powervs_node.go
+++ b/pkg/cloud/powervs_node.go
@@ -25,7 +25,6 @@ import (
 const (
 	PowerVSInstanceStateSHUTOFF = "SHUTOFF"
 	PowerVSInstanceStateACTIVE  = "ACTIVE"
-	PowerVSInstanceHealthOK     = "OK"
 	StoragePoolAffinity         = false
 	ProviderIDValidLength       = 6
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

- Update storage pool affinity of a PVM instance even if its in `WARNING` state
- Ignore calling the update API if the storage pool affinity of the PVM is already in expected state

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```