### PR TITLE
Remove kubernetes version compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ There are couple driver options that can be passed as arguments when starting dr
 # IBM PowerVS Block CSI Driver on Kubernetes
 Following sections are Kubernetes specific. If you are Kubernetes user, use followings for driver features, installation steps and examples.
 
-## Kubernetes Version Compatibility Matrix
-| PowerVS CSI Driver \ Kubernetes Version| v1.23 |
-|----------------------------------------|-------|
-| main branch                          | yes   |
 
 ## Features
 * **Static Provisioning** - create a new or migrating existing PowerVS volumes, then create persistence volume (PV) from the PowerVS volume and consume the PV from container using persistence volume claim (PVC).


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove kubernetes version compatibility matrix as the data is already avaialble in CSI Specification compatibility matrix.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```