### PR TITLE
Updated readme for scale tests

### DIFF
--- a/tests/scale/kube-burner/README.md
+++ b/tests/scale/kube-burner/README.md
@@ -1,15 +1,22 @@
 # Running Scale tests with kube burner
 ## Steps
-- [Download](https://github.com/cloud-bulldozer/kube-burner/releases) kube burner binary
+- Clone this repo and change the working directory to kube-burner
+```
+git clone https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver.git && cd ibm-powervs-block-csi-driver/tests/scale/kube-burner/
+```
+- Download latest kube burner binary from [here](https://github.com/cloud-bulldozer/kube-burner/releases)
+```
+wget https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.1/kube-burner-0.17.1-Linux-ppc64le.tar.gz
+```
 - Untar the tar file
 ```
-tar -xvf kube-burner-0.15.1-Linux-ppc64le.tar.gz 
+tar -xvf kube-burner-0.17.1-Linux-ppc64le.tar.gz 
 ```
 - Create the storage class 
 ```
-kubectl apply -f tests/scale/kube-burner/static/sc.yaml
+kubectl apply -f static/sc.yaml
 ```
 - Run workloads
 ```
-./kube-burner init --uuid=3fs8d0dgdjknwf49s356g3 -c tests/scale/kube-burner/config.yaml
+./kube-burner init --uuid=3fs8d0dgdjknwf49s356g3 -c config.yaml
 ```


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updated the readme with correct information for running the scale tests.
Tested the steps as below.
```
[root@rdr-mdnnew2-6fc4-syd04-bastion-0 check]# git clone https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver.git && cd ibm-powervs-block-csi-driver/tests/scale/kube-burner/
Cloning into 'ibm-powervs-block-csi-driver'...
remote: Enumerating objects: 1390, done.
remote: Counting objects: 100% (135/135), done.
remote: Compressing objects: 100% (104/104), done.
remote: Total 1390 (delta 61), reused 74 (delta 28), pack-reused 1255
Receiving objects: 100% (1390/1390), 9.90 MiB | 18.00 MiB/s, done.
Resolving deltas: 100% (755/755), done.
[root@rdr-mdnnew2-6fc4-syd04-bastion-0 kube-burner]# 


[root@rdr-mdnnew2-6fc4-syd04-bastion-0 kube-burner]# wget https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.1/kube-burner-0.17.1-Linux-ppc64le.tar.gz
--2022-11-02 01:28:25--  https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.1/kube-burner-0.17.1-Linux-ppc64le.tar.gz
Resolving github.com (github.com)... 20.248.137.48
Connecting to github.com (github.com)|20.248.137.48|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/292393392/2763f142-7dc1-4352-a0a5-f406f6f52a80?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221102T052825Z&X-Amz-Expires=300&X-Amz-Signature=8168bf8d4cc82df8a57cd72f14157b70896388c543090bab87942de4aa121cd4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=292393392&response-content-disposition=attachment%3B%20filename%3Dkube-burner-0.17.1-Linux-ppc64le.tar.gz&response-content-type=application%2Foctet-stream [following]
--2022-11-02 01:28:25--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/292393392/2763f142-7dc1-4352-a0a5-f406f6f52a80?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221102T052825Z&X-Amz-Expires=300&X-Amz-Signature=8168bf8d4cc82df8a57cd72f14157b70896388c543090bab87942de4aa121cd4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=292393392&response-content-disposition=attachment%3B%20filename%3Dkube-burner-0.17.1-Linux-ppc64le.tar.gz&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.108.133, 185.199.110.133, 185.199.109.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 21404950 (20M) [application/octet-stream]
Saving to: 'kube-burner-0.17.1-Linux-ppc64le.tar.gz'

kube-burner-0.17.1-Linux-ppc64le.tar.gz                    100%[========================================================================================================================================>]  20.41M  8.66MB/s    in 2.4s    

2022-11-02 01:28:29 (8.66 MB/s) - 'kube-burner-0.17.1-Linux-ppc64le.tar.gz' saved [21404950/21404950]



[root@rdr-mdnnew2-6fc4-syd04-bastion-0 kube-burner]# tar -xvf kube-burner-0.17.1-Linux-ppc64le.tar.gz 
LICENSE
kube-burner


[root@rdr-mdnnew2-6fc4-syd04-bastion-0 kube-burner]# kubectl apply -f static/sc.yaml
storageclass.storage.k8s.io/powervs-sc created


[root@rdr-mdnnew2-6fc4-syd04-bastion-0 kube-burner]# ./kube-burner init --uuid=3fs8d0dgdjknwf49s356g3 -c config.yaml
INFO[2022-11-02 01:29:51] 🔥 Starting kube-burner (0.17.1@0705206f675ed31d49b7e75ec6dc2c2890ba56f9) with UUID 3fs8d0dgdjknwf49s356g3 
INFO[2022-11-02 01:29:51] 📈 Creating measurement factory               
INFO[2022-11-02 01:29:51] Registered measurement: podLatency           
INFO[2022-11-02 01:29:51] Preparing create job: api-intensive-create   
INFO[2022-11-02 01:29:51] Job api-intensive-create: 10 iterations with 10 PersistentVolumeClaim replicas 
INFO[2022-11-02 01:29:51] Job api-intensive-create: 10 iterations with 10 Pod replicas 
INFO[2022-11-02 01:29:51] Preparing delete job: ensure-pods-removal    
INFO[2022-11-02 01:29:51] Job ensure-pods-removal: Delete Pod with selector kube-burner-job=api-intensive-create 
INFO[2022-11-02 01:29:51] Preparing delete job: remove-pvc             
INFO[2022-11-02 01:29:51] Job remove-pvc: Delete PersistentVolumeClaim with selector kube-burner-job=api-intensive-create 
INFO[2022-11-02 01:29:51] Triggering job: api-intensive-create         
INFO[2022-11-02 01:29:52] Creating Pod latency watcher for api-intensive-create 
....
....      
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #260 

**Special notes for your reviewer**:


**Release note**:
```
none
```