### PR TITLE
io/util removed as deprected

### DIFF
--- a/pkg/driver/mount_test.go
+++ b/pkg/driver/mount_test.go
@@ -14,7 +14,6 @@ limitations under the License.
 package driver
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ import (
 
 func TestMakeDir(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-powervs-csi")
+	dir, err := os.MkdirTemp("", "mount-powervs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
@@ -47,7 +46,7 @@ func TestMakeDir(t *testing.T) {
 
 func TestMakeFile(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-powervs-csi")
+	dir, err := os.MkdirTemp("", "mount-powervs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
@@ -73,7 +72,7 @@ func TestMakeFile(t *testing.T) {
 
 func TestExistsPath(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-powervs-csi")
+	dir, err := os.MkdirTemp("", "mount-powervs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
@@ -97,7 +96,7 @@ func TestExistsPath(t *testing.T) {
 
 func TestGetDeviceName(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-powervs-csi")
+	dir, err := os.MkdirTemp("", "mount-powervs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -3,7 +3,6 @@ package driver
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -21,7 +20,7 @@ import (
 
 func TestSanity(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "sanity-powervs-csi")
+	dir, err := os.MkdirTemp("", "sanity-powervs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}

--- a/pkg/fibrechannel/fibrechannel.go
+++ b/pkg/fibrechannel/fibrechannel.go
@@ -18,7 +18,6 @@ package fibrechannel
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -31,7 +30,7 @@ import (
 )
 
 type ioHandler interface {
-	ReadDir(dirname string) ([]os.FileInfo, error)
+	ReadDir(dirname string) ([]os.DirEntry, error)
 	Lstat(name string) (os.FileInfo, error)
 	EvalSymlinks(path string) (string, error)
 	WriteFile(filename string, data []byte, perm os.FileMode) error
@@ -49,8 +48,8 @@ type Connector struct {
 type OSioHandler struct{}
 
 // ReadDir calls the ReadDir function from ioutil package
-func (handler *OSioHandler) ReadDir(dirname string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(dirname)
+func (handler *OSioHandler) ReadDir(dirname string) ([]os.DirEntry, error) {
+	return os.ReadDir(dirname)
 }
 
 // Lstat calls the Lstat function from os package
@@ -65,7 +64,7 @@ func (handler *OSioHandler) EvalSymlinks(path string) (string, error) {
 
 // WriteFile calls WriteFile from ioutil package
 func (handler *OSioHandler) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 // FindMultipathDeviceForDevice given a device name like /dev/sdx, find the devicemapper parent


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removing io/util and use os package as io/util is deprecated.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #286 

**Special notes for your reviewer**:


**Release note**:
```
none
```