### PR TITLE
Updated glog with klog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.29.1
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/davecgh/go-spew v1.1.1
-	github.com/golang/glog v1.0.0
 	github.com/golang/mock v1.6.0
 	github.com/kubernetes-csi/csi-test v2.2.0+incompatible
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -396,7 +396,6 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/fibrechannel/fibrechannel.go
+++ b/pkg/fibrechannel/fibrechannel.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/golang/glog"
+	"k8s.io/klog/v2"
 
 	"errors"
 	"path"
@@ -226,19 +226,19 @@ func findDiskWWIDs(wwid string, io ioHandler) (string, string) {
 			if name == FcPath {
 				disk, err := io.EvalSymlinks(DevID + name)
 				if err != nil {
-					glog.Errorf("fc: failed to find a corresponding disk from symlink[%s], error %v", DevID+name, err)
+					klog.Errorf("fc: failed to find a corresponding disk from symlink[%s], error %v", DevID+name, err)
 					return "", ""
 				}
 				dm, err1 := FindMultipathDeviceForDevice(disk, io)
 				if err1 != nil {
-					glog.Errorf("fc: failed to find a multipath disk for %s, error %v", disk, err)
+					klog.Errorf("fc: failed to find a multipath disk for %s, error %v", disk, err)
 					return disk, ""
 				}
 				return disk, dm
 			}
 		}
 	}
-	glog.Errorf("fc: failed to find a disk [%s]", DevID+FcPath)
+	klog.Errorf("fc: failed to find a disk [%s]", DevID+FcPath)
 	return "", ""
 }
 
@@ -248,11 +248,11 @@ func Attach(c Connector, io ioHandler) (string, error) {
 		io = &OSioHandler{}
 	}
 
-	glog.Infof("Attaching fibre channel volume")
+	klog.Infof("Attaching fibre channel volume")
 	devicePath, err := searchDisk(c, io)
 
 	if err != nil {
-		glog.Infof("unable to find disk given WWNN or WWIDs")
+		klog.Infof("unable to find disk given WWNN or WWIDs")
 		return "", err
 	}
 
@@ -265,7 +265,7 @@ func Detach(devicePath string, io ioHandler) error {
 		io = &OSioHandler{}
 	}
 
-	glog.Infof("Detaching fibre channel volume")
+	klog.Infof("Detaching fibre channel volume")
 	var devices []string
 	dstPath, err := io.EvalSymlinks(devicePath)
 
@@ -280,20 +280,20 @@ func Detach(devicePath string, io ioHandler) error {
 		devices = append(devices, dstPath)
 	}
 
-	glog.Infof("fc: DetachDisk devicePath: %v, dstPath: %v, devices: %v", devicePath, dstPath, devices)
+	klog.Infof("fc: DetachDisk devicePath: %v, dstPath: %v, devices: %v", devicePath, dstPath, devices)
 
 	var lastErr error
 
 	for _, device := range devices {
 		err := detachFCDisk(device, io)
 		if err != nil {
-			glog.Errorf("fc: detachFCDisk failed. device: %v err: %v", device, err)
+			klog.Errorf("fc: detachFCDisk failed. device: %v err: %v", device, err)
 			lastErr = fmt.Errorf("fc: detachFCDisk failed. device: %v err: %v", device, err)
 		}
 	}
 
 	if lastErr != nil {
-		glog.Errorf("fc: last error occurred during detach disk:\n%v", lastErr)
+		klog.Errorf("fc: last error occurred during detach disk:\n%v", lastErr)
 		return lastErr
 	}
 
@@ -333,7 +333,7 @@ func detachFCDisk(devicePath string, io ioHandler) error {
 // Removes a scsi device based upon /dev/sdX name
 func removeFromScsiSubsystem(deviceName string, io ioHandler) error {
 	fileName := "/sys/block/" + deviceName + "/device/delete"
-	glog.Infof("fc: remove device from scsi-subsystem: path: %s", fileName)
+	klog.Infof("fc: remove device from scsi-subsystem: path: %s", fileName)
 	data := []byte("1")
 	err := io.WriteFile(fileName, data, 0666)
 	if err != nil {
@@ -348,6 +348,6 @@ func RemoveMultipathDevice(device string) error {
 	if err != nil {
 		return fmt.Errorf("failed remove multipath device: %s err: %v", device, err)
 	}
-	glog.Infof("output of multipath device remove command: %s", stdoutStderr)
+	klog.Infof("output of multipath device remove command: %s", stdoutStderr)
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
Fixes: #259 
Updated glog with klog.
Issue  #259 is not seen after using log.
```
[root@madhank8s2 ~]# kubectl logs powervs-csi-node-dz4z6  --follow -n kube-system | grep fibrechannel
Defaulted container "powervs-plugin" out of: powervs-plugin, node-driver-registrar, liveness-probe
I1109 07:01:25.154386       1 fibrechannel.go:251] Attaching fibre channel volume
E1109 07:01:25.154559       1 fibrechannel.go:241] fc: failed to find a disk [/dev/disk/by-id/scsi-360050768108002dac800000000000f9a]
E1109 07:01:57.370946       1 fibrechannel.go:241] fc: failed to find a disk [/dev/disk/by-id/scsi-360050768108002dac800000000000f9a]
I1109 07:01:57.370994       1 fibrechannel.go:255] unable to find disk given WWNN or WWIDs
I1109 07:01:57.977907       1 fibrechannel.go:251] Attaching fibre channel volume
E1109 07:01:57.978211       1 fibrechannel.go:241] fc: failed to find a disk [/dev/disk/by-id/scsi-360050768108002dac800000000000f9a]
```


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #259 

**Special notes for your reviewer**:


**Release note**:
```
none
```