### PR TITLE
Adding kube-config and cloud-config args to the driver

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,12 +32,11 @@ func main() {
 
 	drv, err := driver.NewDriver(
 		driver.WithEndpoint(options.ServerOptions.Endpoint),
-		//driver.WithExtraTags(options.ControllerOptions.ExtraTags),
-		//river.WithExtraVolumeTags(options.ControllerOptions.ExtraVolumeTags),
 		driver.WithMode(options.DriverMode),
 		driver.WithDebug(options.ServerOptions.Debug),
 		driver.WithVolumeAttachLimit(options.NodeOptions.VolumeAttachLimit),
-		//driver.WithKubernetesClusterID(options.ControllerOptions.KubernetesClusterID),
+		driver.WithKubeConfig(options.ServerOptions.Kubeconfig),
+		driver.WithCloudConfig(options.ServerOptions.Cloudconfig),
 	)
 	if err != nil {
 		klog.Fatalln(err)

--- a/cmd/options/server_options.go
+++ b/cmd/options/server_options.go
@@ -30,9 +30,15 @@ type ServerOptions struct {
 	Endpoint string
 	// Debug
 	Debug bool
+	// Kubeconfig
+	Kubeconfig string
+	// Cloudconfig
+	Cloudconfig string
 }
 
 func (s *ServerOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.Endpoint, "endpoint", driver.DefaultCSIEndpoint, "Endpoint for the CSI driver server")
 	fs.BoolVar(&s.Debug, "debug", false, "Debug option PowerVS client(Prints API requests and replies)")
+	fs.StringVar(&s.Kubeconfig, "kubeconfig", "", "Kubeconfig of the cluster")
+	fs.StringVar(&s.Cloudconfig, "cloud-config", "", "The path to the cloud provider configuration file. Empty string for no configuration file.")
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	golang.org/x/sys v0.3.0
 	google.golang.org/grpc v1.51.0
+	gopkg.in/gcfg.v1 v1.2.3
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v1.25.4
@@ -126,6 +127,7 @@ require (
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/warnings.v0 v0.1.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1089,6 +1089,8 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
+gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
@@ -1097,6 +1099,8 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/warnings.v0 v0.1.1 h1:XM28wIgFzaBmeZ5dNHIpWLQpt/9DGKxk+rCg/22nnYE=
+gopkg.in/warnings.v0 v0.1.1/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -86,9 +86,9 @@ func TokenizeProviderID(providerID string) (*Metadata, error) {
 }
 
 // Get New Metadata Service
-func NewMetadataService(k8sAPIClient KubernetesAPIClient) (MetadataService, error) {
+func NewMetadataService(k8sAPIClient KubernetesAPIClient, kubeconfig string) (MetadataService, error) {
 	klog.Infof("retrieving instance data from kubernetes api")
-	clientset, err := k8sAPIClient()
+	clientset, err := k8sAPIClient(kubeconfig)
 	if err != nil {
 		klog.Warningf("error creating kubernetes api client: %v", err)
 	} else {

--- a/pkg/cloud/metadata_k8s.go
+++ b/pkg/cloud/metadata_k8s.go
@@ -23,16 +23,15 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
 
-type KubernetesAPIClient func() (kubernetes.Interface, error)
+type KubernetesAPIClient func(kubeconfig string) (kubernetes.Interface, error)
 
 // Get default kubernetes API client
-var DefaultKubernetesAPIClient = func() (kubernetes.Interface, error) {
-	// creates the in-cluster config
-	config, err := rest.InClusterConfig()
+var DefaultKubernetesAPIClient = func(kubeconfig string) (kubernetes.Interface, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -62,6 +62,8 @@ type Options struct {
 	mode              Mode
 	volumeAttachLimit int64
 	debug             bool
+	kubeconfig        string
+	cloudconfig       string
 }
 
 func NewDriver(options ...func(*Options)) (*Driver, error) {
@@ -165,5 +167,17 @@ func WithDebug(debug bool) func(*Options) {
 func WithVolumeAttachLimit(volumeAttachLimit int64) func(*Options) {
 	return func(o *Options) {
 		o.volumeAttachLimit = volumeAttachLimit
+	}
+}
+
+func WithKubeConfig(kubeconfig string) func(*Options) {
+	return func(o *Options) {
+		o.kubeconfig = kubeconfig
+	}
+}
+
+func WithCloudConfig(cloudconfig string) func(*Options) {
+	return func(o *Options) {
+		o.cloudconfig = cloudconfig
 	}
 }

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -74,7 +74,7 @@ type nodeService struct {
 // it panics if failed to create the service
 func newNodeService(driverOptions *Options) nodeService {
 	klog.V(4).Infof("retrieving node info from metadata service")
-	metadata, err := cloud.NewMetadataService(cloud.DefaultKubernetesAPIClient)
+	metadata, err := cloud.NewMetadataService(cloud.DefaultKubernetesAPIClient, driverOptions.kubeconfig)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adding kube-config and cloud-config args to the driver so that, the kubernetes cluster configuration and powervs cloud configuration can be passed to the driver in the run time if available.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```