### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make driver node-update-controller
 
 # debian base image
-FROM k8s.gcr.io/build-image/debian-base:v2.1.3 AS debian-base
+FROM registry.k8s.io/build-image/debian-base:v2.1.3 AS debian-base
 RUN clean-install ca-certificates e2fsprogs mount udev util-linux xfsprogs bash multipath-tools sg3-utils
 COPY --from=builder /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver/bin/* /
 ENTRYPOINT ["/ibm-powervs-block-csi-driver"]

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -26,7 +26,7 @@ spec:
         - operator: Exists
       containers:
         - name: powervs-plugin
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-powervs-block-csi-driver:main
+          image: registry.k8s.io/cloud-provider-ibm/ibm-powervs-block-csi-driver:main
           imagePullPolicy: Always
           args:
             # - {all,controller,node} # specify the driver mode
@@ -63,7 +63,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-update-controller
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-powervs-block-csi-driver:main
+          image: registry.k8s.io/cloud-provider-ibm/ibm-powervs-block-csi-driver:main
           command: ["/node-update-controller"]
           ports:
             - name: metrics
@@ -88,7 +88,7 @@ spec:
                   key: IBMCLOUD_API_KEY
                   optional: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -102,7 +102,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
           args:
             - --csi-address=$(ADDRESS)
             - --timeout=120s
@@ -116,7 +116,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=2
@@ -127,7 +127,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -28,7 +28,7 @@ spec:
         - name: powervs-plugin
           securityContext:
             privileged: true
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-powervs-block-csi-driver:main
+          image: registry.k8s.io/cloud-provider-ibm/ibm-powervs-block-csi-driver:main
           imagePullPolicy: Always
           args:
             - node
@@ -72,7 +72,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -92,7 +92,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -3,15 +3,15 @@ kind: Kustomization
 bases:
   - ../../base
 images:
-  - name: k8s.gcr.io/cloud-provider-ibm/ibm-powervs-block-csi-driver
+  - name: registry.k8s.io/cloud-provider-ibm/ibm-powervs-block-csi-driver
     newTag: v0.3.0
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
+  - name: registry.k8s.io/sig-storage/csi-provisioner
     newTag: v3.3.0
-  - name: k8s.gcr.io/sig-storage/csi-attacher
+  - name: registry.k8s.io/sig-storage/csi-attacher
     newTag: v3.5.1
-  - name: k8s.gcr.io/sig-storage/csi-resizer
+  - name: registry.k8s.io/sig-storage/csi-resizer
     newTag: v1.7.0
-  - name: k8s.gcr.io/sig-storage/livenessprobe
+  - name: registry.k8s.io/sig-storage/livenessprobe
     newTag: v2.9.0
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  - name: registry.k8s.io/sig-storage/csi-node-driver-registrar
     newTag: v2.7.0

--- a/tests/scale/kube-burner/templates/pod.yaml
+++ b/tests/scale/kube-burner/templates/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: app-{{.Iteration}}-{{.Replica}}
-      image: k8s.gcr.io/pause:3.6
+      image: registry.k8s.io/pause:3.6
       command: ["/pause"]
       volumeMounts:
         - name: persistent-storage-{{.Iteration}}-{{.Replica}}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```