### PR TITLE
Remove panic calls and use fatal instead

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -89,7 +89,7 @@ func GetOptions(fs *flag.FlagSet) *Options {
 	}
 
 	if err := fs.Parse(args); err != nil {
-		panic(err)
+		klog.Fatal(err)
 	}
 
 	if *version {

--- a/pkg/cloud/powervs_node.go
+++ b/pkg/cloud/powervs_node.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 )
 
@@ -65,7 +66,7 @@ func NewNodeUpdateScope(params NodeUpdateScopeParams) (scope *NodeUpdateScope, e
 
 	c, err := NewPowerVSCloud(scope.ServiceInstanceId, scope.Zone, false)
 	if err != nil {
-		panic(err)
+		klog.Fatalf("Failed to get powervs cloud: %v", err)
 	}
 	scope.Cloud = c
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -73,17 +73,17 @@ type nodeService struct {
 }
 
 // newNodeService creates a new node service
-// it panics if failed to create the service
+// it will print stack trace and osexit if failed to create the service
 func newNodeService(driverOptions *Options) nodeService {
 	klog.V(4).Infof("retrieving node info from metadata service")
 	metadata, err := cloud.NewMetadataService(cloud.DefaultKubernetesAPIClient, driverOptions.kubeconfig)
 	if err != nil {
-		panic(err)
+		klog.Fatalf("Failed to get metadata service: %v", err)
 	}
 
 	pvsCloud, err := NewPowerVSCloudFunc(metadata.GetCloudInstanceId(), metadata.GetZone(), driverOptions.debug)
 	if err != nil {
-		panic(err)
+		klog.Fatalf("Failed to get powervs cloud: %v", err)
 	}
 
 	return nodeService{


### PR DESCRIPTION
**What type of PR is this?**
1. Change List to Get Service Instance API.
2. Get rid of panic() calls and use Fatal() instead.

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #419

**Special notes for your reviewer**:


**Release note**:
```
none
```