### PR TITLE
reduce multipathd usage as it timeout if large number of disks (OCPBUGS-16878)

### DIFF
--- a/pkg/device/multipath.go
+++ b/pkg/device/multipath.go
@@ -18,11 +18,10 @@ package device
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -33,254 +32,108 @@ const (
 	dmsetupcommand       = "dmsetup"
 	majorMinorPattern    = "(.*)\\((?P<Major>\\d+),\\s+(?P<Minor>\\d+)\\)"
 	orphanPathsPattern   = ".*\\s+(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*orphan"
-	faultyPathsPattern   = ".*failed.*(?P<host>\\d+):(?P<channel>\\d+):(?P<target>\\d+):(?P<lun>\\d+).*faulty"
-	errorMapPattern      = "((?P<mapname>.*):.*error)"
 	deviceDoesNotExist   = "No such device or address"
 	scsiDeviceDeletePath = "/sys/class/scsi_device/%s:%s:%s:%s/device/delete"
 )
 
 var (
 	showPathsFormat  = []string{"show", "paths", "raw", "format", "%w %d %t %i %o %T %z %s %m"}
-	showMapsFormat   = []string{"show", "maps", "raw", "format", "%w %d %n %s"}
-	errorMapRegex    = regexp.MustCompile(errorMapPattern)
 	orphanPathRegexp = regexp.MustCompile(orphanPathsPattern)
-	faultyPathRegexp = regexp.MustCompile(faultyPathsPattern)
-	multipathMutex   sync.Mutex
 )
 
-// PathInfo: struct for multipathd show paths
-type PathInfo struct {
-	UUID     string
-	Device   string
-	DmState  string
-	Hcil     string
-	DevState string
-	ChkState string
-	Checker  string
+// getPathsCount get number of slaves for a given device
+func getPathsCount(mapper string) (count int, err error) {
+	// TODO: This can be achieved reading the full line processing instead of piped command
+	statusCmd := fmt.Sprintf("dmsetup status --target multipath %s | awk 'BEGIN{RS=\" \";active=0}/[0-9]+:[0-9]+/{dev=1}/A/{if (dev == 1) active++; dev=0} END{ print active }'", mapper)
+
+	outBytes, err := exec.Command("bash", "-c", statusCmd).CombinedOutput()
+	out := strings.TrimSuffix(string(outBytes), "\n")
+	if err != nil || isDmsetupStatusError(out) {
+		return 0, fmt.Errorf("error while running dmsetup status command: %s : %v", out, err)
+	}
+	return strconv.Atoi(out)
 }
 
-// retryGetPathOfDevice: get all slaves for a given device
-func retryGetPathOfDevice(dev *Device, needActivePath bool) (paths []PathInfo, err error) {
-	try := 0
-	maxTries := 5
-	for {
-		paths, err := multipathGetPathsOfDevice(dev, needActivePath)
-		if err != nil {
-			if isMultipathTimeoutError(err.Error()) {
-				if try < maxTries {
-					try++
-					time.Sleep(5 * time.Second)
-					continue
-				}
-			}
-			return nil, err
-		}
-		return paths, nil
-	}
+// isDmsetupStatusError check for command failure or empty stdout msg
+func isDmsetupStatusError(msg string) bool {
+	return msg == "" || strings.Contains(msg, "Command failed")
 }
 
-// multipathGetPathsOfDevice: get all scsi paths and host, channel information of multipath device
-func multipathGetPathsOfDevice(dev *Device, needActivePath bool) (paths []PathInfo, err error) {
-	lines, err := multipathdShowCmd(dev.WWID, showPathsFormat)
-	if err != nil {
-		return nil, err
-	}
-	if len(lines) == 0 && dev != nil && dev.WWID != "" {
-		return nil, nil
-	}
-
-	for _, line := range lines {
-		if strings.Contains(line, dev.WWID) {
-			entry := strings.Fields(line)
-			// return all paths if we don't need active paths
-			if !needActivePath {
-				path := &PathInfo{
-					UUID:     entry[0][1:], // entry[0] uuid
-					Device:   entry[1],     // entry[1] dev
-					DmState:  entry[2],     // entry[2] dm_st
-					Hcil:     entry[3],     // entry[3] hcil
-					ChkState: entry[5],     // entry[5] chk_st
-				}
-				paths = append(paths, *path)
-				// return only active paths with chk_st as ready and dm_st as active
-			} else if len(entry) >= 5 && entry[2] == "active" && entry[5] == "ready" {
-				path := &PathInfo{
-					UUID:     entry[0][1:], // entry[0] uuid
-					Device:   entry[1],     // entry[1] dev
-					DmState:  entry[2],     // entry[2] dm_st
-					Hcil:     entry[3],     // entry[3] hcil
-					ChkState: entry[5],     // entry[5] chk_st
-				}
-				paths = append(paths, *path)
-			}
-		}
-	}
-	return paths, nil
-}
-
-// multipathdShowCmd: runs multipathd show ... with given arguments
-func multipathdShowCmd(search string, args []string) (output []string, err error) {
-	multipathMutex.Lock()
-	defer multipathMutex.Unlock()
-
-	out, err := exec.Command(multipathd, args...).CombinedOutput()
-	if err != nil {
-		return nil, err
-	}
-	r, err := regexp.Compile("(?m)^.*" + search + ".*$")
-	if err != nil {
-		return nil, err
-	}
-	listMultipathShowCmdOut := r.FindAllString(string(out), -1)
-	return listMultipathShowCmdOut, nil
-}
-
+// isMultipathTimeoutError check for timeout or similar error msg
 func isMultipathTimeoutError(msg string) bool {
 	return strings.Contains(msg, "timeout") || strings.Contains(msg, "receiving packet")
 }
-func isMultipathBusyError(msg string) bool {
-	return strings.Contains(msg, "Device or resource busy")
-}
 
-// tearDownMultipathDevice: tear down the hiearchy of multipath device and scsi paths
-func tearDownMultipathDevice(dev *Device) (err error) {
-	lines, err := multipathdShowCmd(dev.WWID, showMapsFormat)
-	if err != nil {
-		return err
-	}
-
-	for _, line := range lines {
-		if !strings.Contains(line, dev.WWID) {
-			continue
-		}
-		entry := strings.Fields(line)
-		if len(entry) == 0 || !strings.Contains(entry[0], dev.WWID) {
-			continue
-		}
-		if err := retryCleanupDeviceAndSlaves(dev); err != nil {
-			klog.Warningf("error while deleting multipath device %s: %v", dev.Mapper, err)
-			return err
-		}
-	}
-	return nil
-}
-
-// retryCleanupDeviceAndSlaves: retry for maxtries for device Cleanup
-func retryCleanupDeviceAndSlaves(dev *Device) (err error) {
+// retryCleanupDevice retry for maxtries for device Cleanup
+func retryCleanupDevice(dev *Device) error {
 	maxTries := 10
+	var err error
 	for try := 0; try < maxTries; try++ {
-		err = cleanupDeviceAndSlaves(dev)
+		err = multipathRemoveDmDevice(dev.Mapper)
 		if err == nil {
 			return nil
 		}
 		time.Sleep(5 * time.Second)
 	}
-	return nil
+	return err
 }
 
-// cleanupDeviceAndSlaves: remove the multipath devices and its slaves
-func cleanupDeviceAndSlaves(dev *Device) (err error) {
-	// check for all paths again and make sure we have all paths for cleanup
-	allPaths, err := multipathGetPathsOfDevice(dev, false)
-	if err != nil {
-		return err
-	}
-
-	removeErr := multipathRemoveDmDevice(dev)
-	// delay returning removeErr so we can attempt to delete all the scsi devices
-	// this indicates multipath map cleanup failed, so the caller can retry
-
-	// delete scsi devices (slaves)
-	for _, path := range allPaths {
-		deletePath := fmt.Sprintf("/sys/block/%s/device/delete", path.Device)
-		if err := deleteSdDevice(deletePath); err != nil {
-			klog.Warningf("error while deleting device %s: %v", path, err)
-			// try to cleanup rest of the paths
-		}
-	}
-
-	return removeErr
-}
-
-// multipathDisableQueuing: disable queueing on the multipath device
-func multipathDisableQueuing(dev *Device) (err error) {
-	args := []string{"message", dev.Mapper, "0", "fail_if_no_path"}
+// multipathDisableQueuing disable queueing on the multipath device
+func multipathDisableQueuing(mapper string) (err error) {
+	args := []string{"message", mapper, "0", "fail_if_no_path"}
 	outBytes, err := exec.Command(dmsetupcommand, args...).CombinedOutput()
 	if err != nil {
 		return err
 	}
 	out := string(outBytes)
-	if out != "" && strings.Contains(out, deviceDoesNotExist) {
-		return fmt.Errorf("failed to disable queuing for %s with wwn %s. Error: %s", dev.Mapper, dev.WWN, out)
+	if strings.Contains(out, deviceDoesNotExist) {
+		return fmt.Errorf("cannot disable queuing: %s", out)
 	}
 	return nil
 }
 
-// multipathRemoveDmDevice: remove multipath device via dmsetup
-func multipathRemoveDmDevice(dev *Device) (err error) {
-	multipathMutex.Lock()
-	defer multipathMutex.Unlock()
+// multipathRemoveDmDevice remove multipath device via dmsetup
+func multipathRemoveDmDevice(mapper string) (err error) {
+	if strings.HasSuffix(mapper, "mpatha") {
+		klog.Warning("skipping remove mpatha which is root")
+		return
+	}
 
-	_ = multipathDisableQueuing(dev)
+	err = multipathDisableQueuing(mapper)
+	if err != nil {
+		klog.Warningf("failure while disabling queue for %s: %v", mapper, err)
+	}
 
-	args := []string{"remove", "--force", dev.Mapper}
+	args := []string{"remove", "--force", mapper}
 	outBytes, err := exec.Command(dmsetupcommand, args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to remove multipath map for %s with wwn %s. Error: %v", dev.Mapper, dev.WWN, err)
+		return fmt.Errorf("failed to remove multipath map for %s, error: %v", mapper, err)
 	}
 	out := string(outBytes)
-	if out != "" && !strings.Contains(out, "ok") && !strings.Contains(out, deviceDoesNotExist) {
-		return fmt.Errorf("failed to remove device map for %s with wwn %s. Error: %s", dev.Mapper, dev.WWN, out)
+	if isDmsetupRemoveError(out) {
+		return fmt.Errorf("failed to remove device map for %s, error: %s", mapper, out)
 	}
 	return nil
 }
 
-// cleanupErrorMultipathMaps: find error maps and remove them
-func cleanupErrorMultipathMaps() (err error) {
-	multipathMutex.Lock()
-	defer multipathMutex.Unlock()
-
-	// run dmsetup table and fetch error maps
-	args := []string{"table"}
-	outBytes, err := exec.Command(dmsetupcommand, args...).CombinedOutput()
-	if err != nil {
-		return err
-	}
-
-	listErrorMaps := errorMapRegex.FindAllString(string(outBytes), -1)
-	for _, errorMap := range listErrorMaps {
-		result := findStringSubmatchMap(errorMap, errorMapRegex)
-		if mapName, ok := result["mapname"]; ok {
-			args := []string{"remove", "--force", mapName}
-			if removeOut, err := exec.Command(dmsetupcommand, args...).CombinedOutput(); err == nil {
-				continue
-			} else if isMultipathBusyError(string(removeOut)) {
-				// if device or resource busy
-				// simply try umount and then remove (best effort run only)
-				umountArgs := []string{fmt.Sprintf("/dev/mapper/%s", mapName)}
-				_ = exec.Command("umount", umountArgs...).Run()
-				_ = exec.Command(dmsetupcommand, args...).Run()
-			}
-		}
-	}
-	return nil
+// isDmsetupRemoveError check if dmsetup remove command did not return empty, "ok" or no device msg
+func isDmsetupRemoveError(msg string) bool {
+	return msg != "" && !strings.Contains(msg, "ok") && !strings.Contains(msg, deviceDoesNotExist)
 }
 
-// cleanupOrphanPaths: find orphan paths and remove them
-func cleanupOrphanPaths() (err error) {
-	multipathMutex.Lock()
-	defer multipathMutex.Unlock()
-
+// cleanupOrphanPaths find orphan paths and remove them (best effort)
+func cleanupOrphanPaths() {
 	// run multipathd show paths and fetch orphan maps
 	outBytes, err := exec.Command(multipathd, showPathsFormat...).CombinedOutput()
 	if err != nil {
-		return err
+		klog.Warningf("failed to run multipathd %v, err: %s", showPathsFormat, err)
+		return
 	}
 	out := string(outBytes)
 	// rc can be 0 on the below error conditions as well
 	if isMultipathTimeoutError(out) {
-		err = fmt.Errorf("failed to get multipathd %v, out %s", showPathsFormat, out)
-		return err
+		klog.Warningf("failed to get multipathd %v, out %s", showPathsFormat, out)
+		return
 	}
 
 	listOrphanPaths := orphanPathRegexp.FindAllString(out, -1)
@@ -292,110 +145,4 @@ func cleanupOrphanPaths() (err error) {
 			klog.Warningf("error while deleting device: %v", err)
 		}
 	}
-	return nil
-}
-
-// cleanupStaleMaps: cleanup maps which are not attached to a vend/prod/rev
-func cleanupStaleMaps() (err error) {
-	multipathMutex.Lock()
-	defer multipathMutex.Unlock()
-
-	outBytes, err := exec.Command(multipathd, showMapsFormat...).CombinedOutput()
-	if err != nil {
-		return err
-	}
-	out := string(outBytes)
-	// rc can be 0 on the below error conditions as well
-	if isMultipathTimeoutError(out) {
-		err = fmt.Errorf("failed to get multipathd %v, out %s", showMapsFormat, out)
-		return err
-	}
-	r, err := regexp.Compile("(?m)^.*##,##")
-	if err != nil {
-		return err
-	}
-	staleMultipaths := r.FindAllString(out, -1)
-
-	for _, line := range staleMultipaths {
-		entry := strings.Fields(line)
-		args := []string{"remove", "--force", entry[2]} // entry[2]: map name
-		_, err := exec.Command(dmsetupcommand, args...).CombinedOutput()
-		if err != nil {
-			continue
-		}
-	}
-	return nil
-}
-
-// cleanupFaultyPaths: cleanup paths which are faulty, indicates no storage
-func cleanupFaultyPaths() (err error) {
-	multipathMutex.Lock()
-	defer multipathMutex.Unlock()
-
-	// run multipathd show paths and fetch orphan maps
-	outBytes, err := exec.Command(multipathd, showPathsFormat...).CombinedOutput()
-	if err != nil {
-		return err
-	}
-	out := string(outBytes)
-	// rc can be 0 on the below error conditions as well
-	if isMultipathTimeoutError(out) {
-		err = fmt.Errorf("failed to get multipathd %v, out %s", showPathsFormat, out)
-		return err
-	}
-
-	listFaultyPaths := faultyPathRegexp.FindAllString(out, -1)
-	for _, faultyPath := range listFaultyPaths {
-		result := findStringSubmatchMap(faultyPath, faultyPathRegexp)
-		deletePath := fmt.Sprintf(scsiDeviceDeletePath, result["host"], result["channel"], result["target"], result["lun"])
-		if err := deleteSdDevice(deletePath); err != nil {
-			// ignore errors as its a best effort to cleanup all fulty paths
-			klog.Warningf("error while deleting device: %v", err)
-		}
-	}
-	return nil
-}
-
-// cleanupStalePaths: clean stale scsi devices which can be result of remapped disks
-func cleanupStalePaths() (err error) {
-	// get all maps (.*mpath.*) to clean stale paths in `/sys/class/scsi_device`
-	allMaps, err := multipathdShowCmd("mpath", showMapsFormat)
-	if err != nil {
-		klog.Info(err)
-		return err
-	}
-
-	scsiPath := "/sys/class/scsi_device/"
-	dirs, err := os.ReadDir(scsiPath)
-	if err != nil {
-		return err
-	}
-OUTER:
-	for _, f := range dirs {
-		wwidPath := scsiPath + f.Name() + "/device/wwid"
-		wwid, err := readFirstLine(wwidPath)
-		if err != nil {
-			klog.Warning(err)
-			continue
-		}
-		entries := strings.Split(wwid, ".")
-		if len(entries) <= 1 {
-			continue
-		}
-		wwn := entries[1]
-		for _, line := range allMaps {
-			if strings.Contains(line, wwn) {
-				continue OUTER
-			}
-		}
-
-		// delete stale path if not found
-		hctl := strings.Split(f.Name(), ":")
-		deletePath := fmt.Sprintf(scsiDeviceDeletePath, hctl[0], hctl[1], hctl[2], hctl[3])
-		if err := deleteSdDevice(deletePath); err != nil {
-			// ignore errors as its a best effort to cleanup all stale paths
-			klog.Warningf("error while deleting device: %v", err)
-		}
-	}
-	return nil
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -72,10 +72,8 @@ func TestNodeStageVolume(t *testing.T) {
 			NewDevice = func(wwn string) device.LinuxDevice {
 				return mockDevice
 			}
-			mockDevice.EXPECT().CreateDevice().Return(nil)
 			mockDevice.EXPECT().Populate(false).Return(nil)
 			mockDevice.EXPECT().GetMapper().Return(devicePath).MinTimes(2)
-			mockDevice.EXPECT().DeleteDevice().Return(nil)
 			mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
 
 		}
@@ -100,7 +98,7 @@ func TestNodeStageVolume(t *testing.T) {
 				commonExpectMock(mockMounter, mockDevice)
 				mockMounter.EXPECT().FormatAndMount(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Any(), gomock.Any()).Return(nil)
 				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return(targetPath, 1, nil)
-
+				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil)
 			},
 		},
 
@@ -127,7 +125,6 @@ func TestNodeStageVolume(t *testing.T) {
 
 				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
 				mockMounter.EXPECT().FormatAndMount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-
 			},
 		},
 
@@ -152,7 +149,7 @@ func TestNodeStageVolume(t *testing.T) {
 				commonExpectMock(mockMounter, mockDevice)
 				mockMounter.EXPECT().FormatAndMount(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeExt4), gomock.Eq([]string{"dirsync", "noexec"}))
 				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return(targetPath, 1, nil)
-
+				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil)
 			},
 		},
 
@@ -177,7 +174,7 @@ func TestNodeStageVolume(t *testing.T) {
 				commonExpectMock(mockMounter, mockDevice)
 				mockMounter.EXPECT().FormatAndMount(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeExt3), gomock.Any())
 				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return(targetPath, 1, nil)
-
+				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil)
 			},
 		},
 
@@ -202,7 +199,7 @@ func TestNodeStageVolume(t *testing.T) {
 				commonExpectMock(mockMounter, mockDevice)
 				mockMounter.EXPECT().FormatAndMount(gomock.Eq(devicePath), gomock.Eq(targetPath), gomock.Eq(FSTypeExt4), gomock.Any())
 				mockMounter.EXPECT().GetDeviceName(gomock.Eq(targetPath)).Return(targetPath, 1, nil)
-
+				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil)
 			},
 		},
 
@@ -629,7 +626,7 @@ func TestNodePublishVolume(t *testing.T) {
 					volumeLocks: util.NewVolumeLocks(),
 				}
 
-				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil)
+				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil).Times(2)
 				mockMounter.EXPECT().MakeFile(targetPath).Return(nil)
 				mockMounter.EXPECT().Mount(devicePath, targetPath, "", gomock.Any()).Return(nil)
 
@@ -639,9 +636,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockDevice.EXPECT().GetMapper().Return(devicePath).MinTimes(2)
-				mockDevice.EXPECT().CreateDevice().Return(nil)
 				mockDevice.EXPECT().Populate(false).Return(nil)
-				mockDevice.EXPECT().DeleteDevice().Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: devicePath, WWNKey: wwnValue},
@@ -671,7 +666,7 @@ func TestNodePublishVolume(t *testing.T) {
 					volumeLocks: util.NewVolumeLocks(),
 				}
 
-				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil)
+				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil).Times(2)
 				mockMounter.EXPECT().MakeFile(targetPath).Return(nil)
 				mockMounter.EXPECT().Mount(devicePath, targetPath, "", gomock.Any()).Return(nil)
 
@@ -681,9 +676,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockDevice.EXPECT().GetMapper().Return(devicePath).MinTimes(2)
-				mockDevice.EXPECT().CreateDevice().Return(nil)
 				mockDevice.EXPECT().Populate(false).Return(nil)
-				mockDevice.EXPECT().DeleteDevice().Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: devicePath, WWNKey: wwnValue},
@@ -714,7 +707,7 @@ func TestNodePublishVolume(t *testing.T) {
 					volumeLocks: util.NewVolumeLocks(),
 				}
 
-				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil)
+				mockMounter.EXPECT().ExistsPath(gomock.Any()).Return(true, nil).Times(2)
 				mockMounter.EXPECT().MakeFile(targetPath).Return(nil)
 				mockMounter.EXPECT().Mount(devicePath, targetPath, "", gomock.Any()).Return(nil)
 
@@ -724,9 +717,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockDevice.EXPECT().GetMapper().Return(devicePath).MinTimes(2)
-				mockDevice.EXPECT().CreateDevice().Return(nil)
 				mockDevice.EXPECT().Populate(false).Return(nil)
-				mockDevice.EXPECT().DeleteDevice().Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: devicePath, WWNKey: wwnValue},

--- a/pkg/driver/stats.go
+++ b/pkg/driver/stats.go
@@ -23,7 +23,7 @@ type StatsUtils interface {
 type VolumeStatUtils struct {
 }
 
-// IsDevicePathNotExist ...
+// IsPathNotExist ...
 func (su *VolumeStatUtils) IsPathNotExist(path string) bool {
 	var stat unix.Stat_t
 	err := unix.Stat(path, &stat)


### PR DESCRIPTION
**What type of PR is this?**

/kind flake
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

This PR will not use multipathd commands to list paths or maps for calculating the devices used in the CSI driver. Instead dmsetup command is used which is thread-safe and does not time out in case of a large number of disks.
We can find the number of active disks in a path and use it.
Also, we do not need to handle error or faulty paths. Just removing the mpath for faulty (not active) disks we can handle orphans cleanup which ensures the new disks get detected.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #261 (It is already fixed, this PR will improve on same)

**Special notes for your reviewer**:

Integration tests are run on device pkg. Need to do multiple e2e runs, will confirm once done.

**Release note**:
```
none
```