### PR TITLE
use instance storage type instead of querying for image

### DIFF
--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -33,6 +33,5 @@ type Cloud interface {
 	GetPVMInstanceByID(instanceID string) (instance *PVMInstance, err error)
 	GetPVMInstanceDetails(instanceID string) (*models.PVMInstance, error)
 	UpdateStoragePoolAffinity(instanceID string) error
-	GetImageByID(imageID string) (image *PVMImage, err error)
 	IsAttached(volumeID string, nodeID string) (attached bool, err error)
 }

--- a/pkg/cloud/mocks/mock_cloud.go
+++ b/pkg/cloud/mocks/mock_cloud.go
@@ -123,21 +123,6 @@ func (mr *MockCloudMockRecorder) GetDiskByName(name interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskByName", reflect.TypeOf((*MockCloud)(nil).GetDiskByName), name)
 }
 
-// GetImageByID mocks base method.
-func (m *MockCloud) GetImageByID(imageID string) (*cloud.PVMImage, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageByID", imageID)
-	ret0, _ := ret[0].(*cloud.PVMImage)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetImageByID indicates an expected call of GetImageByID.
-func (mr *MockCloudMockRecorder) GetImageByID(imageID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageByID", reflect.TypeOf((*MockCloud)(nil).GetImageByID), imageID)
-}
-
 // GetPVMInstanceByID mocks base method.
 func (m *MockCloud) GetPVMInstanceByID(instanceID string) (*cloud.PVMInstance, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/powervs.go
+++ b/pkg/cloud/powervs.go
@@ -54,21 +54,14 @@ type powerVSCloud struct {
 
 	cloudInstanceID string
 
-	imageClient        *instance.IBMPIImageClient
 	pvmInstancesClient *instance.IBMPIInstanceClient
 	volClient          *instance.IBMPIVolumeClient
 }
 
 type PVMInstance struct {
-	ID      string
-	ImageID string
-	Name    string
-}
-
-type PVMImage struct {
 	ID       string
-	Name     string
 	DiskType string
+	Name     string
 }
 
 func NewPowerVSCloud(cloudInstanceID, zone string, debug bool) (Cloud, error) {
@@ -104,12 +97,10 @@ func newPowerVSCloud(cloudInstanceID, zone string, debug bool) (Cloud, error) {
 	backgroundContext := context.Background()
 	volClient := instance.NewIBMPIVolumeClient(backgroundContext, piSession, cloudInstanceID)
 	pvmInstancesClient := instance.NewIBMPIInstanceClient(backgroundContext, piSession, cloudInstanceID)
-	imageClient := instance.NewIBMPIImageClient(backgroundContext, piSession, cloudInstanceID)
 
 	return &powerVSCloud{
 		piSession:          piSession,
 		cloudInstanceID:    cloudInstanceID,
-		imageClient:        imageClient,
 		pvmInstancesClient: pvmInstancesClient,
 		volClient:          volClient,
 	}, nil
@@ -123,9 +114,9 @@ func (p *powerVSCloud) GetPVMInstanceByName(name string) (*PVMInstance, error) {
 	for _, pvmInstance := range in.PvmInstances {
 		if name == *pvmInstance.ServerName {
 			return &PVMInstance{
-				ID:      *pvmInstance.PvmInstanceID,
-				ImageID: *pvmInstance.ImageID,
-				Name:    *pvmInstance.ServerName,
+				ID:       *pvmInstance.PvmInstanceID,
+				DiskType: pvmInstance.StorageType,
+				Name:     *pvmInstance.ServerName,
 			}, nil
 		}
 	}
@@ -139,21 +130,9 @@ func (p *powerVSCloud) GetPVMInstanceByID(instanceID string) (*PVMInstance, erro
 	}
 
 	return &PVMInstance{
-		ID:      *in.PvmInstanceID,
-		ImageID: *in.ImageID,
-		Name:    *in.ServerName,
-	}, nil
-}
-
-func (p *powerVSCloud) GetImageByID(imageID string) (*PVMImage, error) {
-	image, err := p.imageClient.Get(imageID)
-	if err != nil {
-		return nil, err
-	}
-	return &PVMImage{
-		ID:       *image.ImageID,
-		Name:     *image.Name,
-		DiskType: *image.StorageType,
+		ID:       *in.PvmInstanceID,
+		DiskType: *in.StorageType,
+		Name:     *in.ServerName,
 	}, nil
 }
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -575,13 +575,9 @@ func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		klog.Errorf("failed to get the instance for pvmInstanceId %s, err: %s", d.pvmInstanceId, err)
 		return nil, fmt.Errorf("failed to get the instance for pvmInstanceId %s, err: %s", d.pvmInstanceId, err)
 	}
-	image, err := d.cloud.GetImageByID(in.ImageID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get the image details for %s, err: %s", in.ImageID, err)
-	}
 
 	segments := map[string]string{
-		DiskTypeKey: image.DiskType,
+		DiskTypeKey: in.DiskType,
 	}
 
 	topology := &csi.Topology{Segments: segments}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1096,14 +1096,8 @@ func TestNodeGetInfo(t *testing.T) {
 			mockCloud := cloudmocks.NewMockCloud(mockCtl)
 
 			mockCloud.EXPECT().GetPVMInstanceByID(tc.instanceID).Return(&cloud.PVMInstance{
-				ID:      tc.instanceID,
-				Name:    tc.name,
-				ImageID: "test-image",
-			}, nil)
-
-			mockCloud.EXPECT().GetImageByID(gomock.Eq("test-image")).Return(&cloud.PVMImage{
-				ID:       "test-image",
-				Name:     "test-image",
+				ID:       tc.instanceID,
+				Name:     tc.name,
 				DiskType: "tier3",
 			}, nil)
 

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -134,21 +134,19 @@ func newFakeCloudProvider() *fakeCloudProvider {
 }
 
 func (p *fakeCloudProvider) GetPVMInstanceByName(name string) (*cloud.PVMInstance, error) {
-
 	return &cloud.PVMInstance{
-		ID:      name + "-" + "id",
-		ImageID: name + "-" + "image",
-		Name:    name,
+		ID:       name + "-" + "id",
+		DiskType: "tier3",
+		Name:     name,
 	}, nil
 
 }
 
 func (p *fakeCloudProvider) GetPVMInstanceByID(instanceID string) (*cloud.PVMInstance, error) {
-
 	return &cloud.PVMInstance{
-		ID:      instanceID,
-		ImageID: strings.Split(instanceID, "-")[0] + "-" + "image",
-		Name:    strings.Split(instanceID, "-")[0],
+		ID:       instanceID,
+		DiskType: "tier3",
+		Name:     strings.Split(instanceID, "-")[0],
 	}, nil
 }
 
@@ -164,15 +162,6 @@ func (p *fakeCloudProvider) GetPVMInstanceDetails(instanceID string) (*models.PV
 func (p *fakeCloudProvider) UpdateStoragePoolAffinity(instanceID string) error {
 
 	return nil
-}
-
-func (p *fakeCloudProvider) GetImageByID(imageID string) (*cloud.PVMImage, error) {
-
-	return &cloud.PVMImage{
-		ID:       imageID,
-		Name:     strings.Split(imageID, "-")[0] + "-" + "image",
-		DiskType: "tier3",
-	}, nil
 }
 
 func (c *fakeCloudProvider) CreateDisk(volumeName string, diskOptions *cloud.DiskOptions) (*cloud.Disk, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Reduces get image api call. We can get storage/disk type from instance response.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```