### PR TITLE
fix: do not fatal on failure to create cloud object

### DIFF
--- a/pkg/cloud/powervs_node.go
+++ b/pkg/cloud/powervs_node.go
@@ -66,7 +66,8 @@ func NewNodeUpdateScope(params NodeUpdateScopeParams) (scope *NodeUpdateScope, e
 
 	c, err := NewPowerVSCloud(scope.ServiceInstanceId, scope.Zone, false)
 	if err != nil {
-		klog.Fatalf("Failed to get powervs cloud: %v", err)
+		klog.Errorf("Failed to get powervs cloud: %v", err)
+		return
 	}
 	scope.Cloud = c
 


### PR DESCRIPTION

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #441

**Special notes for your reviewer**:
The caller will handle any errors in creating the cloud object. We do not need to handle any intermittent cloud api errors, the next reconciler should do the job.

**Release note**:
```
none
```