### PR TITLE
Fix for grpc NewClient failure while running IT

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -64,6 +64,12 @@ func TestParseEndpoint(t *testing.T) {
 		expErr    error
 	}{
 		{
+			name:      "valid tcp endpoint",
+			endpoint:  "tcp://localhost:10000",
+			expScheme: "tcp",
+			expAddr:   "localhost:10000",
+		},
+		{
 			name:      "valid unix endpoint 1",
 			endpoint:  "unix:///csi/csi.sock",
 			expScheme: "unix",

--- a/tests/it/utils.go
+++ b/tests/it/utils.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/resolver"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/driver"
@@ -106,6 +107,7 @@ func verifyRequiredEnvVars(runRemotely bool) {
 
 // newCSIClient creates as CSI client
 func newCSIClient() (*CSIClient, error) {
+	resolver.SetDefaultScheme("passthrough")
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		// grpc.WithBlock(),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
It sets the default schema to "passthrough" to get rid of multiple addresses when using `dns` via GitHub Action.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #624

**Special notes for your reviewer**:


**Release note**:
```
none
```