### PR TITLE
Update and setup dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,19 +21,19 @@ jobs:
       packages: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Action reference: https://github.com/docker/setup-qemu-action
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       # Action reference: https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       # Action reference: https://github.com/docker/login-action
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -43,13 +43,13 @@ jobs:
       # Action reference: https://github.com/ASzc/change-string-case-action
       - id: repository_owner
         name: lower case repository owner name
-        uses: ASzc/change-string-case-action@v1
+        uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ github.repository_owner }}
 
       # Action reference: https://github.com/docker/build-push-action
       - name: Build container
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ./build/base
           platforms: linux/amd64,linux/ppc64le


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

**What this PR does / why we need it**:
This PR contains changes to update Github actions versions to the latest available release and setup dependabot for the same. There were several warnings reported under https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver/actions/runs/7655309827 related to node12 and node16 being deprecated. 

<img width="935" alt="image" src="https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver/assets/110517346/514ae39e-095e-4c79-b4f0-0d8e42d70165">


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
**Special notes for your reviewer**:


**Release note**:
```
none
```