### PR TITLE
Supress kustomize warnings for deprecated fields

### DIFF
--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
 resources:
-  - clusterrole-attacher.yaml
-  - clusterrole-csi-node.yaml
-  - clusterrole-provisioner.yaml
-  - clusterrole-resizer.yaml
-  - clusterrolebinding-attacher.yaml
-  - clusterrolebinding-csi-node.yaml
-  - clusterrolebinding-provisioner.yaml
-  - clusterrolebinding-resizer.yaml
-  - controller.yaml
-  - csidriver.yaml
-  - node.yaml
-  - serviceaccount-csi-controller.yaml
-  - serviceaccount-csi-node.yaml
+- clusterrole-attacher.yaml
+- clusterrole-csi-node.yaml
+- clusterrole-provisioner.yaml
+- clusterrole-resizer.yaml
+- clusterrolebinding-attacher.yaml
+- clusterrolebinding-csi-node.yaml
+- clusterrolebinding-provisioner.yaml
+- clusterrolebinding-resizer.yaml
+- controller.yaml
+- csidriver.yaml
+- node.yaml
+- serviceaccount-csi-controller.yaml
+- serviceaccount-csi-node.yaml

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
-patchesStrategicMerge:
-  - main_image.yaml
+resources:
+- ../../base
+patches:
+- path: main_image.yaml

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,17 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
 images:
-  - name: registry.k8s.io/cloud-provider-ibm/ibm-powervs-block-csi-driver
-    newTag: v0.6.0
-  - name: registry.k8s.io/sig-storage/csi-provisioner
-    newTag: v4.0.0
-  - name: registry.k8s.io/sig-storage/csi-attacher
-    newTag: v4.5.0
-  - name: registry.k8s.io/sig-storage/csi-resizer
-    newTag: v1.9.3
-  - name: registry.k8s.io/sig-storage/livenessprobe
-    newTag: v2.13.0
-  - name: registry.k8s.io/sig-storage/csi-node-driver-registrar
-    newTag: v2.10.0
+- name: registry.k8s.io/cloud-provider-ibm/ibm-powervs-block-csi-driver
+  newTag: v0.6.0
+- name: registry.k8s.io/sig-storage/csi-provisioner
+  newTag: v4.0.0
+- name: registry.k8s.io/sig-storage/csi-attacher
+  newTag: v4.5.0
+- name: registry.k8s.io/sig-storage/csi-resizer
+  newTag: v1.9.3
+- name: registry.k8s.io/sig-storage/livenessprobe
+  newTag: v2.13.0
+- name: registry.k8s.io/sig-storage/csi-node-driver-registrar
+  newTag: v2.10.0
+resources:
+- ../../base


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR contains changes to avoid deprecated fields in kustomize.yaml, whenever a configuration is applied.
```
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Release note**:
```
none
```