### PR TITLE
Use livenessprobe:v2.12.0.

### DIFF
--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -10,7 +10,7 @@ images:
 - name: registry.k8s.io/sig-storage/csi-resizer
   newTag: v1.9.3
 - name: registry.k8s.io/sig-storage/livenessprobe
-  newTag: v2.13.0
+  newTag: v2.12.0
 - name: registry.k8s.io/sig-storage/csi-node-driver-registrar
   newTag: v2.10.0
 resources:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR points the livenessprobe image to the latest available version, as v2.13.0 is unavailable.

```
[root@k8s-csi-tester-2 overlays]# kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
kube-system   calico-kube-controllers-6df7596dbd-t867p   1/1     Running   0          137m
kube-system   calico-node-6r5v6                          1/1     Running   0          3h27m
kube-system   calico-node-sgx7s                          1/1     Running   0          135m
kube-system   coredns-7db6d8ff4d-7f7z5                   1/1     Running   0          137m
kube-system   coredns-7db6d8ff4d-pqx76                   1/1     Running   0          137m
kube-system   etcd-k8s-csi-tester-2                      1/1     Running   0          135m
kube-system   kube-apiserver-k8s-csi-tester-2            1/1     Running   0          135m
kube-system   kube-controller-manager-k8s-csi-tester-2   1/1     Running   0          135m
kube-system   kube-proxy-mgx7h                           1/1     Running   0          3h27m
kube-system   kube-proxy-qmqg9                           1/1     Running   0          135m
kube-system   kube-scheduler-k8s-csi-tester-2            1/1     Running   0          135m
kube-system   powervs-csi-controller-5c6f6b46b9-z4ww5    6/6     Running   0          5m42s
kube-system   powervs-csi-node-h67f9                     3/3     Running   0          5m42s
kube-system   powervs-csi-node-wpqsz                     3/3     Running   0          5m42s
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #686 

**Special notes for your reviewer**:
This change will be required to be cherry-picked to release-0.6, as the same image version is being used.

**Release note**:
```
Fix livenessprobe ErrImagePul/ImagePullBackOff issue.
```