### PR TITLE
Bump CentOS image to stream 9

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 # centos base image
-FROM quay.io/centos/centos:stream8 AS centos-base
+FROM quay.io/centos/centos:stream9 AS centos-base
 RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR bumps the container image to be used from CentOS stream 8 to stream 9, which is used in `Build ibm-powervs-block-csi-driver-centos-base` action.

```
0.889   - Curl error (6): Couldn't resolve host name for http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppStream&infra=container [Could not resolve host: mirrorlist.centos.org]
0.896 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: Curl error (6): Couldn't resolve host name for http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppStream&infra=container [Could not resolve host: mirrorlist.centos.org]
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```