### PR TITLE
Remove execinquery linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - dogsled
     - errcheck
     - errchkjson
-    - execinquery
     # - gci
     - goconst
     # - gocritic


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
execinquery is a deprecated linter and it needs to be removed.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #832 

**Special notes for your reviewer**:


**Release note**:
```
none
```