### PR TITLE
Improve time taken to create/delete volumes

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -20,7 +20,10 @@ package driver
 
 // constants of keys in PublishContext.
 const (
-	WWNKey = "wwn"
+	WWNKey      = "wwn"
+	DiskType    = "diskType"
+	DiskName    = "name"
+	IsShareable = "shareable"
 )
 
 // constants of keys in volume parameters.

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -18,13 +18,16 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	gcfg "gopkg.in/gcfg.v1"
+	"gopkg.in/gcfg.v1"
 
 	"k8s.io/klog/v2"
 
@@ -129,6 +132,7 @@ func newControllerService(driverOptions *Options) controllerService {
 
 func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	klog.V(4).Infof("CreateVolume: called with args %+v", req)
+	start := time.Now()
 	volName := req.GetName()
 	if volName == "" {
 		return nil, status.Error(codes.InvalidArgument, "Volume name not provided")
@@ -152,7 +156,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if !isValidVolumeCapabilities(volCaps) {
 		modes := util.GetAccessModes(volCaps)
 		stringModes := strings.Join(*modes, ", ")
-		errString := "Volume capabilities " + stringModes + " not supported. Only AccessModes [ReadWriteOnce], [ReadWriteMany], [ReadOnlyMany] supported."
+		errString := fmt.Sprintf("Volume capabilities %s not supported. Only AccessModes [ReadWriteOnce], [ReadWriteMany], [ReadOnlyMany] supported.", stringModes)
 		return nil, status.Error(codes.InvalidArgument, errString)
 	}
 
@@ -167,9 +171,8 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	shareable := isShareableVolume(volCaps)
 	opts := &cloud.DiskOptions{
-		Shareable:     shareable,
+		Shareable:     isShareableVolume(volCaps),
 		CapacityBytes: volSizeBytes,
 		VolumeType:    volumeType,
 	}
@@ -178,26 +181,29 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return handleClone(d.cloud, req, volName, volSizeBytes, opts)
 	}
 
-	// check if disk exists
-	// disk exists only if previous createVolume request fails due to any network/tcp error
-	diskDetails, _ := d.cloud.GetDiskByName(volName)
-	if diskDetails != nil {
+	// Check if the disk already exists
+	// Disk exists only if previous createVolume request fails due to any network/tcp error
+	disk, _ := d.cloud.GetDiskByName(volName)
+	if disk != nil {
 		// wait for volume to be available as the volume already exists
-		err := verifyVolumeDetails(opts, diskDetails)
+		klog.V(3).Infof("CreateVolume: Found an existing volume %s in %q state.", volName, disk.State)
+		err := verifyVolumeDetails(opts, disk)
 		if err != nil {
 			return nil, err
 		}
-		err = d.cloud.WaitForVolumeState(diskDetails.VolumeID, cloud.VolumeAvailableState)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Disk already exists and not in expected state")
+		if disk.State != cloud.VolumeAvailableState {
+			err = d.cloud.WaitForVolumeState(disk.VolumeID, cloud.VolumeAvailableState)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "Disk exists, but not in required state. Current:%s Required:%s", disk.State, cloud.VolumeAvailableState)
+			}
 		}
-		return newCreateVolumeResponse(diskDetails, req.VolumeContentSource), nil
+	} else {
+		disk, err = d.cloud.CreateDisk(volName, opts)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not create volume %q: %v", volName, err)
+		}
 	}
-
-	disk, err := d.cloud.CreateDisk(volName, opts)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not create volume %q: %v", volName, err)
-	}
+	klog.V(3).Infof("CreateVolume: created volume %s, took %s", volName, time.Since(start))
 	return newCreateVolumeResponse(disk, req.VolumeContentSource), nil
 }
 
@@ -229,6 +235,7 @@ func (d *controllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 
 func (d *controllerService) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	klog.V(4).Infof("ControllerPublishVolume: called with args %+v", req)
+	start := time.Now()
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -243,7 +250,6 @@ func (d *controllerService) ControllerPublishVolume(ctx context.Context, req *cs
 	if nodeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "Node ID not provided")
 	}
-
 	volCap := req.GetVolumeCapability()
 	if volCap == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability not provided")
@@ -253,44 +259,42 @@ func (d *controllerService) ControllerPublishVolume(ctx context.Context, req *cs
 	if !isValidVolumeCapabilities(caps) {
 		modes := util.GetAccessModes(caps)
 		stringModes := strings.Join(*modes, ", ")
-		errString := "Volume capabilities " + stringModes + " not supported. Only AccessModes [ReadWriteOnce], [ReadWriteMany], [ReadOnlyMany] supported."
+		errString := fmt.Sprintf("Volume capabilities %s not supported. Only AccessModes [ReadWriteOnce], [ReadWriteMany], [ReadOnlyMany] supported.", stringModes)
 		return nil, status.Error(codes.InvalidArgument, errString)
 	}
-
-	if _, err := d.cloud.GetPVMInstanceByID(nodeID); err != nil {
+	// Retrieve the details of the VM, which contains the set of disks attached too.
+	pvInst, err := d.cloud.GetPVMInstanceDetails(nodeID)
+	if err != nil {
 		return nil, status.Errorf(codes.NotFound, "Instance %q not found, err: %v", nodeID, err)
 	}
 
-	disk, err := d.cloud.GetDiskByID(volumeID)
+	pvInfo := map[string]string{WWNKey: req.VolumeContext[WWNKey]}
 
-	if err != nil {
-		if err == cloud.ErrNotFound {
-			return nil, status.Error(codes.NotFound, "Volume not found")
+	for _, vId := range pvInst.VolumeIDs {
+		// If the volumeID of the request matches with the ID of the disk that is attached to the VM, return success.
+		if vId == volumeID {
+			klog.V(4).Infof("ControllerPublishVolume: volume %s already attached to node %s, took %s", volumeID, nodeID, time.Since(start))
+			return &csi.ControllerPublishVolumeResponse{PublishContext: pvInfo}, nil
 		}
-		return nil, status.Errorf(codes.Internal, "Could not get volume with ID %q: %v", volumeID, err)
 	}
-
-	pvInfo := map[string]string{WWNKey: disk.WWN}
-
-	if err = d.cloud.IsAttached(volumeID, nodeID); err == nil {
-		klog.V(5).Infof("ControllerPublishVolume: volume %s already attached to node %s, returning success", volumeID, nodeID)
-		return &csi.ControllerPublishVolumeResponse{PublishContext: pvInfo}, nil
-	}
-
+	// When there are no associated disks, attach the created disk to the VM.
 	err = d.cloud.AttachDisk(volumeID, nodeID)
 	if err != nil {
 		if err == cloud.ErrAlreadyExists {
 			return nil, status.Error(codes.AlreadyExists, err.Error())
 		}
+		if err == cloud.ErrNotFound {
+			return nil, status.Errorf(codes.NotFound, "Could not attach volume %q to node %q: %v", volumeID, nodeID, err)
+		}
 		return nil, status.Errorf(codes.Internal, "Could not attach volume %q to node %q: %v", volumeID, nodeID, err)
 	}
-	klog.V(5).Infof("ControllerPublishVolume: volume %s attached to node %s", volumeID, nodeID)
-
+	klog.V(4).Infof("ControllerPublishVolume: volume %s attached to node %s, took %s", volumeID, nodeID, time.Since(start))
 	return &csi.ControllerPublishVolumeResponse{PublishContext: pvInfo}, nil
 }
 
 func (d *controllerService) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	klog.V(4).Infof("ControllerUnpublishVolume: called with args %+v", req)
+	start := time.Now()
 	volumeID := req.GetVolumeId()
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -306,23 +310,21 @@ func (d *controllerService) ControllerUnpublishVolume(ctx context.Context, req *
 		return nil, status.Error(codes.InvalidArgument, "Node ID not provided")
 	}
 
-	if _, err := d.cloud.GetDiskByID(volumeID); err != nil {
-		if err == cloud.ErrNotFound {
-			klog.V(4).Info("ControllerUnpublishVolume: volume not found, returning with success")
-			return &csi.ControllerUnpublishVolumeResponse{}, nil
+	pvInst, err := d.cloud.GetPVMInstanceDetails(nodeID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "Instance %q not found, err: %v", nodeID, err)
+	}
+
+	for _, vId := range pvInst.VolumeIDs {
+		if vId == volumeID {
+			klog.V(4).Infof("ControllerUnpublishVolume: Detaching volume %s from node %s", volumeID, nodeID)
+			if err := d.cloud.DetachDisk(volumeID, nodeID); err != nil {
+				return nil, status.Errorf(codes.Internal, "Could not detach volume %q from node %q: %v", volumeID, nodeID, err)
+			}
 		}
 	}
-
-	if err := d.cloud.IsAttached(volumeID, nodeID); err != nil {
-		klog.V(4).Infof("ControllerUnpublishVolume: volume %s is not attached to %s, err: %v, returning with success", volumeID, nodeID, err)
-		return &csi.ControllerUnpublishVolumeResponse{}, nil
-	}
-
-	if err := d.cloud.DetachDisk(volumeID, nodeID); err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not detach volume %q from node %q: %v", volumeID, nodeID, err)
-	}
-	klog.V(5).Infof("ControllerUnpublishVolume: volume %s detached from node %s", volumeID, nodeID)
-
+	// The volume in not associated, return success.
+	klog.V(4).Infof("ControllerUnpublishVolume: volume %s is detached from node %s, took %s", volumeID, nodeID, time.Since(start))
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
@@ -461,11 +463,17 @@ func (d *controllerService) ListSnapshots(ctx context.Context, req *csi.ListSnap
 }
 
 func newCreateVolumeResponse(disk *cloud.Disk, src *csi.VolumeContentSource) *csi.CreateVolumeResponse {
+	volumeContext := map[string]string{
+		DiskType:    disk.DiskType,
+		WWNKey:      disk.WWN,
+		DiskName:    disk.Name,
+		IsShareable: strconv.FormatBool(disk.Shareable),
+	}
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      disk.VolumeID,
 			CapacityBytes: util.GiBToBytes(disk.CapacityGiB),
-			VolumeContext: map[string]string{},
+			VolumeContext: volumeContext,
 			ContentSource: src,
 		},
 	}
@@ -488,14 +496,13 @@ func getVolSizeBytes(req *csi.CreateVolumeRequest) (int64, error) {
 
 func verifyVolumeDetails(payload *cloud.DiskOptions, diskDetails *cloud.Disk) error {
 	if payload.Shareable != diskDetails.Shareable {
-		return status.Errorf(codes.Internal, "shareable in payload and shareable in disk details don't match")
+		return status.Errorf(codes.Internal, "Field mismatch for 'Shareable'. Payload:%+v, Available: %+v", payload.Shareable, diskDetails.Shareable)
 	}
 	if payload.VolumeType != diskDetails.DiskType {
-		return status.Errorf(codes.Internal, "TYPE in payload and disktype in disk details don't match")
+		return status.Errorf(codes.Internal, "Field mismatch for 'VolumeType'. Payload:%+v, Available: %+v", payload.VolumeType, diskDetails.DiskType)
 	}
-	capacityGIB := util.BytesToGiB(payload.CapacityBytes)
-	if capacityGIB != diskDetails.CapacityGiB {
-		return status.Errorf(codes.Internal, "capacityBytes in payload and capacityGIB in disk details don't match")
+	if util.BytesToGiB(payload.CapacityBytes) != diskDetails.CapacityGiB {
+		return status.Errorf(codes.Internal, "Field mismatch for 'CapacityGiB'. Payload:%+v, Available: %+v", util.BytesToGiB(payload.CapacityBytes), diskDetails.CapacityGiB)
 	}
 	return nil
 }
@@ -506,35 +513,34 @@ func handleClone(cloud cloud.Cloud, req *csi.CreateVolumeRequest, volName string
 	case *csi.VolumeContentSource_Volume:
 		diskDetails, _ := cloud.GetDiskByNamePrefix("clone-" + req.GetName())
 		if diskDetails != nil {
-			err := verifyVolumeDetails(opts, diskDetails)
-			if err != nil {
+			if err := verifyVolumeDetails(opts, diskDetails); err != nil {
 				return nil, err
 			}
 			return newCreateVolumeResponse(diskDetails, req.VolumeContentSource), nil
 		}
 		if srcVolume := volumeSource.GetVolume(); srcVolume != nil {
+			var err error
 			srcVolumeID := srcVolume.GetVolumeId()
-			diskDetails, err := cloud.GetDiskByID(srcVolumeID)
+			diskDetails, err = cloud.GetDiskByID(srcVolumeID)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not get the source volume %q: %v", srcVolumeID, err)
 			}
 			if util.GiBToBytes(diskDetails.CapacityGiB) != volSizeBytes {
 				return nil, status.Errorf(codes.Internal, "Cannot clone volume %v, source volume size is not equal to the clone volume", srcVolumeID)
 			}
-			err = verifyVolumeDetails(opts, diskDetails)
-			if err != nil {
+			if err = verifyVolumeDetails(opts, diskDetails); err != nil {
 				return nil, err
 			}
 			diskFromSourceVolume, err := cloud.CloneDisk(srcVolumeID, volName)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not clone volume %q: %v", volName, err)
 			}
-			cloneDiskDetails, err := cloud.GetDiskByID(diskFromSourceVolume.VolumeID)
+			diskDetails, err = cloud.GetDiskByID(diskFromSourceVolume.VolumeID)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not get volume %q after clone: %v", volName, err)
 			}
-			return newCreateVolumeResponse(cloneDiskDetails, req.VolumeContentSource), nil
 		}
+		return newCreateVolumeResponse(diskDetails, req.VolumeContentSource), nil
 	}
 	return nil, status.Errorf(codes.InvalidArgument, "%v not a proper volume source", volumeSource)
 }

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -19,13 +19,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
-	mocks "sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud/mocks"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud/mocks"
 	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 )
 
@@ -57,7 +58,7 @@ func TestCreateVolume(t *testing.T) {
 	}{
 
 		{
-			name: "success normal",
+			name: "create a standard volume",
 			testFunc: func(t *testing.T) {
 				req := &csi.CreateVolumeRequest{
 					Name:               "random-vol-name",
@@ -92,7 +93,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
@@ -146,7 +147,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
@@ -192,7 +193,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
@@ -246,7 +247,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
@@ -301,7 +302,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
@@ -356,11 +357,10 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
-
 		{
 			name: "fail no name",
 			testFunc: func(t *testing.T) {
@@ -397,7 +397,6 @@ func TestCreateVolume(t *testing.T) {
 				}
 			},
 		},
-
 		{
 			name: "success same name and same capacity",
 			testFunc: func(t *testing.T) {
@@ -445,7 +444,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 
 				// Subsequent call returns the created disk
@@ -457,7 +456,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 
 				vol := resp.GetVolume()
@@ -487,7 +486,6 @@ func TestCreateVolume(t *testing.T) {
 				}
 			},
 		},
-
 		{
 			name: "success no capacity range",
 			testFunc: func(t *testing.T) {
@@ -529,7 +527,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 
 				vol := resp.GetVolume()
@@ -591,7 +589,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 
 				vol := resp.GetVolume()
@@ -649,7 +647,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
@@ -698,7 +696,7 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
@@ -738,12 +736,12 @@ func TestCreateVolume(t *testing.T) {
 					t.Fatalf("Could not get error status code from error: %v", srvErr)
 				}
 				if srvErr.Code() != codes.InvalidArgument {
-					t.Fatalf("Expect InvalidArgument but got: %s", srvErr.Code())
+					t.Fatalf("Expect InvalidArgument but got: %s", srvErr)
 				}
 			},
 		},
 		{
-			name: "Pass with no volume type parameter",
+			name: "pass with no volume type parameter",
 			testFunc: func(t *testing.T) {
 				// iops 5000 requires at least 10GB
 				volSize := int64(20 * 1024 * 1024 * 1024)
@@ -786,12 +784,12 @@ func TestCreateVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 			},
 		},
 		{
-			name: "fail locked volume request",
+			name: "perform operation on a volume that has a lock",
 			testFunc: func(t *testing.T) {
 				req := &csi.CreateVolumeRequest{
 					Name:               "random-vol-name",
@@ -832,7 +830,7 @@ func TestDeleteVolume(t *testing.T) {
 		testFunc func(t *testing.T)
 	}{
 		{
-			name: "success normal",
+			name: "successful deletion of volume",
 			testFunc: func(t *testing.T) {
 				req := &csi.DeleteVolumeRequest{
 					VolumeId: "vol-test",
@@ -857,7 +855,7 @@ func TestDeleteVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 				if !reflect.DeepEqual(resp, expResp) {
 					t.Fatalf("Expected resp to be %+v, got: %+v", expResp, resp)
@@ -865,7 +863,7 @@ func TestDeleteVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "success invalid volume id",
+			name: "return error if an invalid volume ID is passed",
 			testFunc: func(t *testing.T) {
 				req := &csi.DeleteVolumeRequest{
 					VolumeId: "invalid-volume-name",
@@ -889,7 +887,7 @@ func TestDeleteVolume(t *testing.T) {
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
-					t.Fatalf("Unexpected error: %v", srvErr.Code())
+					t.Fatalf("Unexpected error: %v", srvErr)
 				}
 				if !reflect.DeepEqual(resp, expResp) {
 					t.Fatalf("Expected resp to be %+v, got: %+v", expResp, resp)
@@ -922,7 +920,7 @@ func TestDeleteVolume(t *testing.T) {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
 					}
 					if srvErr.Code() != codes.Internal {
-						t.Fatalf("Unexpected error: %v", srvErr.Code())
+						t.Fatalf("Unexpected error: %v", srvErr)
 					}
 				} else {
 					t.Fatalf("Expected error, got nil")
@@ -984,12 +982,15 @@ func TestControllerPublishVolume(t *testing.T) {
 	}{
 
 		{
-			name: "success normal",
+			name: "successful publication of a newly provisioned volume",
 			testFunc: func(t *testing.T) {
 				req := &csi.ControllerPublishVolumeRequest{
 					NodeId:           expInstanceID,
 					VolumeCapability: stdVolCap,
 					VolumeId:         volumeName,
+					VolumeContext: map[string]string{
+						WWNKey: expDevicePath,
+					},
 				}
 				expResp := &csi.ControllerPublishVolumeResponse{
 					PublishContext: map[string]string{WWNKey: expDevicePath},
@@ -1001,9 +1002,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetPVMInstanceByID(gomock.Eq(expInstanceID)).Return(nil, nil)
-				mockCloud.EXPECT().GetDiskByID(gomock.Eq(volumeName)).Return(&cloud.Disk{WWN: expDevicePath}, nil)
-				mockCloud.EXPECT().IsAttached(gomock.Eq(volumeName), gomock.Eq(expInstanceID)).Return(errors.New("the disk is unattached"))
+				mockCloud.EXPECT().GetPVMInstanceDetails(gomock.Eq(expInstanceID)).Return(&models.PVMInstance{VolumeIDs: []string{"ea0a8972-2132-486d-b9f2-6d97d2a52592", "e3fdc39b-5df8-43c4-9b82-d268d2a7230b"}}, nil)
 				mockCloud.EXPECT().AttachDisk(gomock.Eq(volumeName), gomock.Eq(expInstanceID)).Return(nil)
 
 				powervsDriver := controllerService{
@@ -1179,7 +1178,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetPVMInstanceByID(gomock.Eq("does-not-exist")).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetPVMInstanceDetails(gomock.Eq("does-not-exist")).Return(nil, cloud.ErrNotFound)
 				// mockCloud.EXPECT().IsExistInstance(gomock.Eq(ctx), gomock.Eq(req.NodeId)).Return(false)
 
 				powervsDriver := controllerService{
@@ -1217,8 +1216,8 @@ func TestControllerPublishVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetPVMInstanceByID(gomock.Eq(expInstanceID)).Return(nil, nil)
-				mockCloud.EXPECT().GetDiskByID(gomock.Eq("does-not-exist")).Return(&cloud.Disk{}, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetPVMInstanceDetails(gomock.Eq(expInstanceID)).Return(&models.PVMInstance{VolumeIDs: []string{"ea0a8972-2132-486d-b9f2-6d97d2a52592", "e3fdc39b-5df8-43c4-9b82-d268d2a7230b"}}, nil)
+				mockCloud.EXPECT().AttachDisk(gomock.Eq("does-not-exist"), gomock.Eq(expInstanceID)).Return(cloud.ErrNotFound)
 
 				powervsDriver := controllerService{
 					cloud:         mockCloud,
@@ -1274,7 +1273,6 @@ func TestControllerPublishVolume(t *testing.T) {
 }
 
 func TestControllerUnpublishVolume(t *testing.T) {
-	expDevicePath := "/dev/xvda"
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)
@@ -1294,8 +1292,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetDiskByID(gomock.Eq("vol-test")).Return(&cloud.Disk{WWN: expDevicePath}, nil)
-				mockCloud.EXPECT().IsAttached(gomock.Eq("vol-test"), gomock.Eq(expInstanceID)).Return(nil)
+				mockCloud.EXPECT().GetPVMInstanceDetails(gomock.Eq(expInstanceID)).Return(&models.PVMInstance{VolumeIDs: []string{"vol-test", "boot-vol"}}, nil)
 				mockCloud.EXPECT().DetachDisk(req.VolumeId, req.NodeId).Return(nil)
 
 				powervsDriver := controllerService{
@@ -1329,7 +1326,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetDiskByID(gomock.Eq("vol-test")).Return(&cloud.Disk{WWN: expDevicePath}, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetPVMInstanceDetails(gomock.Eq(expInstanceID)).Return(&models.PVMInstance{VolumeIDs: []string{"boot-vol"}}, nil)
 
 				powervsDriver := controllerService{
 					cloud:         mockCloud,

--- a/tests/e2e/testsuites/testsuites.go
+++ b/tests/e2e/testsuites/testsuites.go
@@ -382,19 +382,9 @@ func (t *TestDeployment) Exec(command []string, expectedString string) {
 
 func (t *TestDeployment) DeletePodAndWait() {
 	framework.Logf("Deleting pod %q in namespace %q", t.podName, t.namespace.Name)
-	err := t.client.CoreV1().Pods(t.namespace.Name).Delete(context.TODO(), t.podName, metav1.DeleteOptions{})
+	err := e2epod.DeletePodWithWaitByName(context.TODO(), t.client, t.podName, t.namespace.Name)
 	if err != nil {
-		if !apierrs.IsNotFound(err) {
-			framework.ExpectNoError(fmt.Errorf("pod %q Delete API error: %v", t.podName, err))
-		}
-		return
-	}
-	framework.Logf("Waiting for pod %q in namespace %q to be fully deleted", t.podName, t.namespace.Name)
-	err = e2epod.WaitForPodNoLongerRunningInNamespace(context.TODO(), t.client, t.podName, t.namespace.Name)
-	if err != nil {
-		if !apierrs.IsNotFound(err) {
-			framework.ExpectNoError(fmt.Errorf("pod %q error waiting for delete: %v", t.podName, err))
-		}
+		framework.ExpectNoError(fmt.Errorf("pod %q error waiting for delete: %v", t.podName, err))
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR makes usage of different cloud APIs to achieve the same as the existing flow.  The changes made improve the time taken to handle the cloud calls for the Create+Publish calls has now reduced to ~33s from the existing ~40 seconds (Over repeated tests).

And with the delete flow, the time associated with the Unpublish stage is about ~15 seconds with the changes vs ~22 seconds earlier.



A few changes are also made to capture the information related to the disks itself:
Earlier:
```
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            powervs.csi.ibm.com
    FSType:            xfs
    VolumeHandle:      xxx-x-xxx-xxx-xxx
    ReadOnly:          false
    VolumeAttributes:      storage.kubernetes.io/csiProvisionerIdentity=x-x-x-x-x-powervs.csi.ibm.com
Events:                <none>
```
With the changes:
```
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            powervs.csi.ibm.com
    FSType:            xfs
    VolumeHandle:     xxx-x-xxx-xxx-xxx
    ReadOnly:          false
    VolumeAttributes:      diskType=tier3
                           name=pvc-xxxx-xxxx-xxx-xxxx
                           shareable=false
                           storage.kubernetes.io/csiProvisionerIdentity=x-x-x-x-x-powervs.csi.ibm.com
                           wwn=xxxxxxxxxxxxxxxxxxx
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1006 

**Special notes for your reviewer**:


**Release note**:
```
Capture disk related information such as tier, wwn, etc. under `VolumeAttributes`.
Clean up Publish and Unpublish flow.
```