### PR TITLE
Adopt GetAllDisks than depend on APIs tied to PowerVS instances

### DIFF
--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -31,9 +31,8 @@ type Cloud interface {
 	WaitForCloneStatus(taskId string) error
 	GetDiskByName(name string) (disk *Disk, err error)
 	GetDiskByNamePrefix(namePrefix string) (disk *Disk, err error)
+	GetAllPVMInstanceDisks(instanceID string) (volumes *models.Volumes, err error)
 	GetDiskByID(volumeID string) (disk *Disk, err error)
-	GetPVMInstanceByName(instanceName string) (instance *PVMInstance, err error)
-	GetPVMInstanceByID(instanceID string) (instance *PVMInstance, err error)
 	GetPVMInstanceDetails(instanceID string) (*models.PVMInstance, error)
 	UpdateStoragePoolAffinity(instanceID string) error
 	IsAttached(volumeID string, nodeID string) (err error)

--- a/pkg/cloud/mocks/mock_cloud.go
+++ b/pkg/cloud/mocks/mock_cloud.go
@@ -127,6 +127,21 @@ func (mr *MockCloudMockRecorder) DetachDisk(volumeID, nodeID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachDisk", reflect.TypeOf((*MockCloud)(nil).DetachDisk), volumeID, nodeID)
 }
 
+// GetAllPVMInstanceDisks mocks base method.
+func (m *MockCloud) GetAllPVMInstanceDisks(instanceID string) (*models.Volumes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllPVMInstanceDisks", instanceID)
+	ret0, _ := ret[0].(*models.Volumes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllPVMInstanceDisks indicates an expected call of GetAllPVMInstanceDisks.
+func (mr *MockCloudMockRecorder) GetAllPVMInstanceDisks(instanceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPVMInstanceDisks", reflect.TypeOf((*MockCloud)(nil).GetAllPVMInstanceDisks), instanceID)
+}
+
 // GetDiskByID mocks base method.
 func (m *MockCloud) GetDiskByID(volumeID string) (*cloud.Disk, error) {
 	m.ctrl.T.Helper()
@@ -170,36 +185,6 @@ func (m *MockCloud) GetDiskByNamePrefix(namePrefix string) (*cloud.Disk, error) 
 func (mr *MockCloudMockRecorder) GetDiskByNamePrefix(namePrefix any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskByNamePrefix", reflect.TypeOf((*MockCloud)(nil).GetDiskByNamePrefix), namePrefix)
-}
-
-// GetPVMInstanceByID mocks base method.
-func (m *MockCloud) GetPVMInstanceByID(instanceID string) (*cloud.PVMInstance, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPVMInstanceByID", instanceID)
-	ret0, _ := ret[0].(*cloud.PVMInstance)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPVMInstanceByID indicates an expected call of GetPVMInstanceByID.
-func (mr *MockCloudMockRecorder) GetPVMInstanceByID(instanceID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPVMInstanceByID", reflect.TypeOf((*MockCloud)(nil).GetPVMInstanceByID), instanceID)
-}
-
-// GetPVMInstanceByName mocks base method.
-func (m *MockCloud) GetPVMInstanceByName(instanceName string) (*cloud.PVMInstance, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPVMInstanceByName", instanceName)
-	ret0, _ := ret[0].(*cloud.PVMInstance)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPVMInstanceByName indicates an expected call of GetPVMInstanceByName.
-func (mr *MockCloudMockRecorder) GetPVMInstanceByName(instanceName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPVMInstanceByName", reflect.TypeOf((*MockCloud)(nil).GetPVMInstanceByName), instanceName)
 }
 
 // GetPVMInstanceDetails mocks base method.

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -584,16 +584,17 @@ func (d *nodeService) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 }
 
 func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+	var segments map[string]string
 	klog.V(4).Infof("NodeGetInfo: called with args %+v", req)
 
-	in, err := d.cloud.GetPVMInstanceByID(d.pvmInstanceId)
-	if err != nil {
+	in, err := d.cloud.GetPVMInstanceDetails(d.pvmInstanceId)
+	if err != nil || in == nil {
 		klog.Errorf("failed to get the instance for pvmInstanceId %s, err: %s", d.pvmInstanceId, err)
 		return nil, fmt.Errorf("failed to get the instance for pvmInstanceId %s, err: %s", d.pvmInstanceId, err)
 	}
 
-	segments := map[string]string{
-		DiskTypeKey: in.DiskType,
+	segments = map[string]string{
+		DiskTypeKey: *in.StorageType,
 	}
 
 	topology := &csi.Topology{Segments: segments}

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
-	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
-	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 
 	"k8s.io/mount-utils"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
+	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
 )
 
 func TestSanity(t *testing.T) {
@@ -134,14 +136,6 @@ func newFakeCloudProvider() *fakeCloudProvider {
 	}
 }
 
-func (p *fakeCloudProvider) GetPVMInstanceByName(name string) (*cloud.PVMInstance, error) {
-	return &cloud.PVMInstance{
-		ID:       name + "-" + "id",
-		DiskType: "tier3",
-		Name:     name,
-	}, nil
-}
-
 func (p *fakeCloudProvider) CheckStorageTierAvailability(storageTier string) error {
 	if storageTier == "tier3" || storageTier == "tier1" || storageTier == "tier5k" || storageTier == "tier0" {
 		return nil
@@ -149,18 +143,17 @@ func (p *fakeCloudProvider) CheckStorageTierAvailability(storageTier string) err
 	return errors.New("not a valid storageTier")
 }
 
-func (p *fakeCloudProvider) GetPVMInstanceByID(instanceID string) (*cloud.PVMInstance, error) {
-	return &cloud.PVMInstance{
-		ID:       instanceID,
-		DiskType: "tier3",
-		Name:     strings.Split(instanceID, "-")[0],
-	}, nil
+func (p *fakeCloudProvider) GetAllPVMInstanceDisks(_ string) (volumes *models.Volumes, err error) {
+	return &models.Volumes{Volumes: []*models.VolumeReference{{
+		VolumeID: ptr.To("123"),
+	}}}, nil
 }
 
 func (p *fakeCloudProvider) GetPVMInstanceDetails(instanceID string) (*models.PVMInstance, error) {
 	return &models.PVMInstance{
 		PvmInstanceID: &instanceID,
 		ServerName:    &strings.Split(instanceID, "-")[0],
+		StorageType:   ptr.To("tier3"),
 	}, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
This PR uses APIs tied to volumes than depend on PowerVS instance related APIs. This allows to limit the data retrieved to just the fields relevant for operations.

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1015 

**Special notes for your reviewer**:


**Release note**:
```
Adopt GetAllDisks than depend on APIs tied to PowerVS instances
```