### PR TITLE
Clean up Publish and Unpublish calls to speed up operations

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -54,6 +54,18 @@ var (
 
 	// ErrAlreadyExists is returned when a resource is already existent.
 	ErrAlreadyExists = errors.New("resource already exists")
+
+	ErrVolumeNameAlreadyExists = errors.New("volume name already exists for cloud instance")
+
+	ErrVolumeNotFound = errors.New("volume not found")
+
+	ErrConflictVolumeAlreadyExists = errors.New("Conflict: unable to attach volumes to the server")
+
+	ErrBadRequestVolumeNotFound = errors.New("Bad Request: the following volumes do not exist")
+
+	ErrPVInstanceNotFound = errors.New("pvm-instance not found")
+
+	ErrVolumeDetachNotFound = errors.New("volume does not exist")
 )
 
 // Disk represents a PowerVS volume.

--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -31,7 +31,6 @@ type Cloud interface {
 	WaitForCloneStatus(taskId string) error
 	GetDiskByName(name string) (disk *Disk, err error)
 	GetDiskByNamePrefix(namePrefix string) (disk *Disk, err error)
-	GetAllPVMInstanceDisks(instanceID string) (volumes *models.Volumes, err error)
 	GetDiskByID(volumeID string) (disk *Disk, err error)
 	GetPVMInstanceDetails(instanceID string) (*models.PVMInstance, error)
 	UpdateStoragePoolAffinity(instanceID string) error

--- a/pkg/cloud/mocks/mock_cloud.go
+++ b/pkg/cloud/mocks/mock_cloud.go
@@ -127,21 +127,6 @@ func (mr *MockCloudMockRecorder) DetachDisk(volumeID, nodeID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachDisk", reflect.TypeOf((*MockCloud)(nil).DetachDisk), volumeID, nodeID)
 }
 
-// GetAllPVMInstanceDisks mocks base method.
-func (m *MockCloud) GetAllPVMInstanceDisks(instanceID string) (*models.Volumes, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllPVMInstanceDisks", instanceID)
-	ret0, _ := ret[0].(*models.Volumes)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllPVMInstanceDisks indicates an expected call of GetAllPVMInstanceDisks.
-func (mr *MockCloudMockRecorder) GetAllPVMInstanceDisks(instanceID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPVMInstanceDisks", reflect.TypeOf((*MockCloud)(nil).GetAllPVMInstanceDisks), instanceID)
-}
-
 // GetDiskByID mocks base method.
 func (m *MockCloud) GetDiskByID(volumeID string) (*cloud.Disk, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -143,12 +143,6 @@ func (p *fakeCloudProvider) CheckStorageTierAvailability(storageTier string) err
 	return errors.New("not a valid storageTier")
 }
 
-func (p *fakeCloudProvider) GetAllPVMInstanceDisks(_ string) (volumes *models.Volumes, err error) {
-	return &models.Volumes{Volumes: []*models.VolumeReference{{
-		VolumeID: ptr.To("123"),
-	}}}, nil
-}
-
 func (p *fakeCloudProvider) GetPVMInstanceDetails(instanceID string) (*models.PVMInstance, error) {
 	return &models.PVMInstance{
 		PvmInstanceID: &instanceID,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR makes changes around Publish and Unpublish stages which improves the time taken to claim and unclaim volumes. This is done by doing away with Cloud API calls which are mostly checks before performing the actual operation. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1006 

**Special notes for your reviewer**:


**Release note**:
```
Clean up Publish and Unpublish flows
```