### PR TITLE
Add support for tier0 and tier5k storage in supported regions

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -23,15 +23,20 @@ import (
 )
 
 // PowerVS volume types.
+// More information: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-on-cloud-architecture#storage-tiers
 const (
-	VolumeTypeTier1 = "tier1"
-	VolumeTypeTier3 = "tier3"
+	VolumeTypeTier0  = "tier0"  // 25 IOPS/GB
+	VolumeTypeTier1  = "tier1"  // 10 IOPS/GB
+	VolumeTypeTier3  = "tier3"  // 3 IOPS/GB
+	VolumeTypeTier5k = "tier5k" // 5000 IOPS regardless of size
 )
 
 var (
 	ValidVolumeTypes = []string{
 		VolumeTypeTier1,
 		VolumeTypeTier3,
+		VolumeTypeTier5k,
+		VolumeTypeTier0,
 	}
 )
 

--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -37,4 +37,5 @@ type Cloud interface {
 	GetPVMInstanceDetails(instanceID string) (*models.PVMInstance, error)
 	UpdateStoragePoolAffinity(instanceID string) error
 	IsAttached(volumeID string, nodeID string) (err error)
+	CheckStorageTierAvailability(storageType string) error
 }

--- a/pkg/cloud/mocks/mock_cloud.go
+++ b/pkg/cloud/mocks/mock_cloud.go
@@ -21,6 +21,7 @@ import (
 type MockCloud struct {
 	ctrl     *gomock.Controller
 	recorder *MockCloudMockRecorder
+	isgomock struct{}
 }
 
 // MockCloudMockRecorder is the mock recorder for MockCloud.
@@ -54,6 +55,20 @@ func (mr *MockCloudMockRecorder) AttachDisk(volumeID, nodeID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachDisk", reflect.TypeOf((*MockCloud)(nil).AttachDisk), volumeID, nodeID)
 }
 
+// CheckStorageTierAvailability mocks base method.
+func (m *MockCloud) CheckStorageTierAvailability(storageType string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckStorageTierAvailability", storageType)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckStorageTierAvailability indicates an expected call of CheckStorageTierAvailability.
+func (mr *MockCloudMockRecorder) CheckStorageTierAvailability(storageType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckStorageTierAvailability", reflect.TypeOf((*MockCloud)(nil).CheckStorageTierAvailability), storageType)
+}
+
 // CloneDisk mocks base method.
 func (m *MockCloud) CloneDisk(sourceVolumeName, cloneVolumeName string) (*cloud.Disk, error) {
 	m.ctrl.T.Helper()
@@ -64,7 +79,7 @@ func (m *MockCloud) CloneDisk(sourceVolumeName, cloneVolumeName string) (*cloud.
 }
 
 // CloneDisk indicates an expected call of CloneDisk.
-func (mr *MockCloudMockRecorder) CloneDisk(sourceVolumeName, cloneVolumeName interface{}) *gomock.Call {
+func (mr *MockCloudMockRecorder) CloneDisk(sourceVolumeName, cloneVolumeName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloneDisk", reflect.TypeOf((*MockCloud)(nil).CloneDisk), sourceVolumeName, cloneVolumeName)
 }
@@ -152,7 +167,7 @@ func (m *MockCloud) GetDiskByNamePrefix(namePrefix string) (*cloud.Disk, error) 
 }
 
 // GetDiskByNamePrefix indicates an expected call of GetDiskByNamePrefix.
-func (mr *MockCloudMockRecorder) GetDiskByNamePrefix(namePrefix interface{}) *gomock.Call {
+func (mr *MockCloudMockRecorder) GetDiskByNamePrefix(namePrefix any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskByNamePrefix", reflect.TypeOf((*MockCloud)(nil).GetDiskByNamePrefix), namePrefix)
 }
@@ -254,7 +269,7 @@ func (m *MockCloud) WaitForCloneStatus(taskId string) error {
 }
 
 // WaitForCloneStatus indicates an expected call of WaitForCloneStatus.
-func (mr *MockCloudMockRecorder) WaitForCloneStatus(taskId interface{}) *gomock.Call {
+func (mr *MockCloudMockRecorder) WaitForCloneStatus(taskId any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForCloneStatus", reflect.TypeOf((*MockCloud)(nil).WaitForCloneStatus), taskId)
 }

--- a/pkg/cloud/powervs.go
+++ b/pkg/cloud/powervs.go
@@ -375,11 +375,11 @@ func (p *powerVSCloud) CheckStorageTierAvailability(storageType string) error {
 	// API Docs for Storagetypes: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-on-cloud-architecture#IOPS-api
 	storageTiers, err := p.storageTierClient.GetAll()
 	if err != nil {
-		return fmt.Errorf("an error occurred while retriving the Storage tier availability. err:%v", err)
+		return fmt.Errorf("unable to fetch all volume types for the given cloud instance. err:%v", err)
 	}
 	for _, storageTier := range storageTiers {
 		if storageTier.Name == storageType && *storageTier.State == "inactive" {
-			return fmt.Errorf("the requested storage tier is not available in the provided cloud instance. Please retry with a different tier")
+			return fmt.Errorf("the requested volume type is not available in the provided cloud instance. Please retry with a different tier")
 		}
 	}
 	return nil

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
-	"k8s.io/mount-utils"
-
 	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud"
 	"sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/util"
+
+	"k8s.io/mount-utils"
 )
 
 func TestSanity(t *testing.T) {
@@ -140,6 +140,13 @@ func (p *fakeCloudProvider) GetPVMInstanceByName(name string) (*cloud.PVMInstanc
 		DiskType: "tier3",
 		Name:     name,
 	}, nil
+}
+
+func (p *fakeCloudProvider) CheckStorageTierAvailability(storageTier string) error {
+	if storageTier == "tier3" || storageTier == "tier1" || storageTier == "tier5k" || storageTier == "tier0" {
+		return nil
+	}
+	return errors.New("not a valid storageTier")
 }
 
 func (p *fakeCloudProvider) GetPVMInstanceByID(instanceID string) (*cloud.PVMInstance, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR allows the support to enable tier0 and tier5k in available regions.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #587 

**Special notes for your reviewer**:


**Release note**:
```
Add support for tier0 and tier5k volumes in supported regions
```