### PR TITLE
Pass on volume details when disk is in available state

### DIFF
--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -27,7 +27,7 @@ type Cloud interface {
 	DetachDisk(volumeID string, nodeID string) (err error)
 	ResizeDisk(volumeID string, reqSize int64) (newSize int64, err error)
 	CloneDisk(sourceVolumeName string, cloneVolumeName string) (disk *Disk, err error)
-	WaitForVolumeState(volumeID, state string) error
+	WaitForVolumeState(volumeID, state string) (*models.Volume, error)
 	WaitForCloneStatus(taskId string) error
 	GetDiskByName(name string) (disk *Disk, err error)
 	GetDiskByNamePrefix(namePrefix string) (disk *Disk, err error)

--- a/pkg/cloud/mocks/mock_cloud.go
+++ b/pkg/cloud/mocks/mock_cloud.go
@@ -245,11 +245,12 @@ func (mr *MockCloudMockRecorder) WaitForCloneStatus(taskId any) *gomock.Call {
 }
 
 // WaitForVolumeState mocks base method.
-func (m *MockCloud) WaitForVolumeState(volumeID, state string) error {
+func (m *MockCloud) WaitForVolumeState(volumeID, state string) (*models.Volume, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForVolumeState", volumeID, state)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*models.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // WaitForVolumeState indicates an expected call of WaitForVolumeState.

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -206,8 +206,8 @@ func (c *fakeCloudProvider) IsAttached(volumeID string, nodeID string) (err erro
 	return nil
 }
 
-func (c *fakeCloudProvider) WaitForVolumeState(volumeID, expectedState string) error {
-	return nil
+func (c *fakeCloudProvider) WaitForVolumeState(volumeID, expectedState string) (*models.Volume, error) {
+	return &models.Volume{VolumeID: ptr.To("a1b2c3-d4e5f6")}, nil
 }
 
 func (c *fakeCloudProvider) WaitForCloneStatus(cloneTaskId string) error {
@@ -224,7 +224,7 @@ func (c *fakeCloudProvider) GetDiskByName(name string) (*cloud.Disk, error) {
 	} else if len(disks) == 1 {
 		return disks[0].Disk, nil
 	}
-	return nil, nil
+	return nil, cloud.ErrNotFound
 }
 
 func (c *fakeCloudProvider) GetDiskByNamePrefix(namePrefix string) (*cloud.Disk, error) {

--- a/tests/e2e/pre_provisioning.go
+++ b/tests/e2e/pre_provisioning.go
@@ -96,7 +96,7 @@ var _ = Describe("[powervs-csi-e2e]Pre-Provisioned", func() {
 	AfterEach(func() {
 		skipManuallyDeletingVolume = true
 		if !skipManuallyDeletingVolume {
-			err := cloud.WaitForVolumeState(volumeID, "detached")
+			_, err := cloud.WaitForVolumeState(volumeID, "detached")
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Detach volume has failed. err: %v", err))
 			err = cloud.DeleteDisk(volumeID)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Disk deletion has failed. err: %v", err))


### PR DESCRIPTION
**What type of PR is this?**


<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:
This PR mitigates the flakey-nature of passing-on Volume related information at the early stages of creation, which may have multiple fields unavailable when the volume is creating as observed in the recent failing Integration test suites. 
Added supporting changes to capture information of the volume when available before proceeding with the subsequent phases. 

**Which issue(s) this PR fixes**: 
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1021 

**Special notes for your reviewer**:
* Ran IT locally multiple times, no issues observed, along with e2e.
* No stale/duplicate volumes are observed on the cloud-side.

```
Integration tests:

Ran 1 of 1 Specs in 39.243 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (39.24s)
PASS
ok  	sigs.k8s.io/ibm-powervs-block-csi-driver/tests/it	39.263s


[root@kishen-test ibm-powervs-block-csi-driver]# git log --shortstat -n1
commit 4c99745e8ee63a9f448801ca1642a4f653ed2856 (HEAD -> fix-it, origin/fix-it)
Author: Kishen Viswanathan <kishen.viswanathan@ibm.com>
Date:   Sun Nov 23 13:57:35 2025 +0530

    Pass on volume details when disk is in available state

 7 files changed, 65 insertions(+), 45 deletions(-)
 ```
 
 ```e2e
 [root@kishen-mayuka-powervs-csi--1 ibm-powervs-block-csi-driver]# make test-e2e
go test -v -timeout 100m sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e -run ^TestE2E$
  W1208 09:08:13.972545 3889990 test_context.go:542] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I1208 09:08:13.972626 3889990 test_context.go:565] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
=== RUN   TestE2E
Running Suite: IBM PowerVS Block CSI Driver End-to-End Tests - /root/kishen/ibm-powervs-block-csi-driver/tests/e2e
==================================================================================================================
Random Seed: 1765202893

Will run 20 of 20 specs
•SSSS••••••••••••S••

Ran 15 of 20 Specs in 2047.842 seconds
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 5 Skipped
--- PASS: TestE2E (2047.84s)
PASS
ok  	sigs.k8s.io/ibm-powervs-block-csi-driver/tests/e2e	2047.893s
[root@kishen-mayuka-powervs-csi--1 ibm-powervs-block-csi-driver]# git remote -v
origin	https://github.com/kishen-v/ibm-powervs-block-csi-driver.git (fetch)
origin	https://github.com/kishen-v/ibm-powervs-block-csi-driver.git (push)
[root@kishen-mayuka-powervs-csi--1 ibm-powervs-block-csi-driver]# git branch
* fix-it
  ```




**Release note**:
```
Fix broken integration tests
```