### PR TITLE
Update default image from CentOS-Stream-8 to Stream-9 for Integration tests

### DIFF
--- a/tests/remote/pi_resources.go
+++ b/tests/remote/pi_resources.go
@@ -41,7 +41,7 @@ func (r *Remote) createPVSResources() (err error) {
 	}
 
 	if image, err = getEnvVar("POWERVS_IMAGE"); err != nil {
-		image = "CentOS-Stream-8"
+		image = "CentOS-Stream-9"
 		if err = r.createImage(image); err != nil {
 			return fmt.Errorf("error while creating ibm pi image: %v", err)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR bumps the default image used for VM deployment in the case of Integration tests to use CentOS-Stream-9, as CentOS Stream 8 has reached EOL.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
The workspace that runs the integration tests does have the CentOS Stream 9 image imported.

**Release note**:
```
Update default image from CentOS-Stream-8 to CentOS-Stream-9 for Integration tests.
```