### PR TITLE
Handle volume state conflicts if the volume is already attached

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -63,6 +63,8 @@ var (
 
 	ErrBadRequestVolumeNotFound = errors.New("Bad Request: the following volumes do not exist")
 
+	ErrVolumesPostConflict = errors.New("volume has status 'in-use'")
+
 	ErrPVInstanceNotFound = errors.New("pvm-instance not found")
 
 	ErrVolumeDetachNotFound = errors.New("volume does not exist")

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-
 	// FSTypeExt2 represents the ext2 filesystem type.
 	FSTypeExt2 = "ext2"
 	// FSTypeExt3 represents the ext3 filesystem type.
@@ -45,10 +44,11 @@ const (
 	// FSTypeXfs represents te xfs filesystem type.
 	FSTypeXfs = "xfs"
 	// default file system type to be used when it is not provided.
-	defaultFsType = "ext4"
+	defaultFsType = FSTypeExt4
 
 	// defaultMaxVolumesPerInstance is the limit of volumes can be attached in the PowerVS environment.
-	// TODO: rightnow 99 is just a placeholder, this needs to be changed post discussion with PowerVS team.
+	// The Virtual Server instance can have more than 127 data volumes (upto 500) but with certain limitations.
+	// See: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server#config-large-vol
 	defaultMaxVolumesPerInstance = 127 - 1
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR handles the case where the volume may be attached from the previous API call, but due to a subsequent reconciliation, trying to attach an already attached volume leads to a state conflict. The changes allow to remediate the attach failure by confirming that the volume is indeed attached to the LPAR and returning successfully.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #1058

**Special notes for your reviewer**:


**Release note**:
```
Handle volume state conflicts if the volume is already attached
```