### PR TITLE
Adopt centos10-minimal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=builder /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver/bin/* /
 ENTRYPOINT ["/ibm-powervs-block-csi-driver"]
 
 # centos base image
-FROM --platform=$TARGETPLATFORM quay.io/centos/centos:stream9 AS centos-base
-RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates device-mapper-multipath && yum clean all && rm -rf /var/cache/yum
+FROM --platform=$TARGETPLATFORM quay.io/centos/centos:stream10-minimal AS centos-base
+RUN microdnf install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates device-mapper-multipath && microdnf clean all && rm -rf /var/cache/yum
 COPY --from=builder /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver/bin/* /
 ENTRYPOINT ["/ibm-powervs-block-csi-driver"]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR leverages the usage of centos 10 minimal image.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested e2e minimally with `tier3` storage.
```
go: downloading github.com/opencontainers/go-digest v1.0.0
  W0513 14:12:35.838964   95321 test_context.go:541] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  I0513 14:12:35.839079 95321 test_context.go:564] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
=== RUN   TestE2E
Running Suite: IBM PowerVS Block CSI Driver End-to-End Tests - /root/ibm-powervs-block-csi-driver/tests/e2e
===========================================================================================================
Random Seed: 1778681555

Will run 17 of 17 specs
•••••••••S••SSSS
•

Ran 12 of 17 Specs in 2352.724 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 5 Skipped
```


**Release note**:
```
Bump base image used for driver to CentOS 10 minimal.
```