### PR TITLE
Pin GitHub Actions to commit hashes rather than versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,19 +21,19 @@ jobs:
       packages: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Action reference: https://github.com/docker/setup-qemu-action
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       # Action reference: https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       # Action reference: https://github.com/docker/login-action
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -43,13 +43,13 @@ jobs:
       # Action reference: https://github.com/ASzc/change-string-case-action
       - id: repository_owner
         name: lower case repository owner name
-        uses: ASzc/change-string-case-action@v8
+        uses: ASzc/change-string-case-action@ecd1412d078f2e06e9eedcbaa6fcd988151c3f82 # v8
         with:
           string: ${{ github.repository_owner }}
 
       # Action reference: https://github.com/docker/build-push-action
       - name: Build container
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./build/base
           platforms: linux/amd64,linux/ppc64le


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR pins the GitHub actions to their respective commits rather than the versions. Currently the workflows fail due to certain policies. [Ref.](https://github.com/kubernetes-sigs/ibm-powervs-block-csi-driver/actions/runs/28544894680/job/84627629517)
```
Error: The actions actions/checkout@v7, docker/setup-qemu-action@v4, docker/setup-buildx-action@v4, docker/login-action@v4, 
aszc/change-string-case-action@v8, and 1 other are not allowed in kubernetes-sigs/ibm-powervs-block-csi-driver because all actions must be pinned to a full-length commit SHA.
```


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```